### PR TITLE
PyUSB 1.0.0b2 API fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+build

--- a/killerbee/dev_rzusbstick.py
+++ b/killerbee/dev_rzusbstick.py
@@ -272,7 +272,7 @@ class RZUSBSTICK:
             if len(data) != res:
                 raise Exception("Issue writing USB data {0} to endpoint {1}, got a return of {2}.".format(data, endpoint, res))
             try:
-                response = self.dev.read(RZ_USB_RESPONSE_EP, self.dev.bMaxPacketSize0, 0, 500)
+                response = self.dev.read(RZ_USB_RESPONSE_EP, self.dev.bMaxPacketSize0, timeout=500)
                 response = response.pop()
             except usb.core.USBError as e:
                 if e.errno != 110: #Not Operation timed out
@@ -450,7 +450,7 @@ class RZUSBSTICK:
                         raise e
         else: # pyUSB 1.x
             try:
-                pdata = self.dev.read(RZ_USB_PACKET_EP, self.dev.bMaxPacketSize0)#1, 0, 100)
+                pdata = self.dev.read(RZ_USB_PACKET_EP, self.dev.bMaxPacketSize0, timeout=timeout)
             except usb.core.USBError as e:
                 if e.errno != 110: #Operation timed out
                     print "Error args:", e.args

--- a/killerbee/dev_rzusbstick.py
+++ b/killerbee/dev_rzusbstick.py
@@ -241,8 +241,8 @@ class RZUSBSTICK:
             return [''.join([self.__bus.dirname, ":", self.dev.filename]), self.dev.open().getString(self.dev.iProduct, 50), self.dev.open().getString(self.dev.iSerialNumber, 12)]
         elif USBVER == 1:
             return ["{0}:{1}".format(self.dev.bus, self.dev.address),         \
-                    usb.util.get_string(self.dev, 50, self.dev.iProduct),     \
-                    usb.util.get_string(self.dev, 50, self.dev.iSerialNumber) ]
+                    usb.util.get_string(self.dev, self.dev.iProduct),     \
+                    usb.util.get_string(self.dev, self.dev.iSerialNumber) ]
 
     def __usb_write(self, endpoint, data):
         '''

--- a/killerbee/kbutils.py
+++ b/killerbee/kbutils.py
@@ -14,6 +14,7 @@ import serial
 import os, glob
 import time
 import random
+import inspect
 from struct import pack
 
 from config import *       #to get DEV_ENABLE_* variables
@@ -138,8 +139,8 @@ def devlist_usb_v1x(vendor=None, product=None):
             # Note, can use "{0:03d}:{1:03d}" to get the old format,
             # but have decided to move to the new, shorter format.
             devlist.append(["{0}:{1}".format(dev.bus, dev.address),         \
-                            usb.util.get_string(dev, 50, dev.iProduct),     \
-                            usb.util.get_string(dev, 50, dev.iSerialNumber)])
+                            usb.util.get_string(dev, dev.iProduct),     \
+                            usb.util.get_string(dev, dev.iSerialNumber)])
     except usb.core.USBError as e:
         if e.errno == 13: #usb.core.USBError: [Errno 13] Access denied (insufficient permissions)
             raise Exception("Unable to open device. " +
@@ -505,3 +506,22 @@ class KBInterfaceError(KBException):
     '''
     pass
 
+
+def pyusb_1x_patch():
+    '''Monkey-patch pyusb 1.x for API compatibility
+    '''
+
+    '''
+    In pyusb v1.0.0b2 (git dac78933), they removed the "length" parameter
+    to usb.util.get_string(). We'll monkey-patch older versions so we don't
+    have to ever pass this argument.
+    '''
+    if 'length' in inspect.getargspec(usb.util.get_string).args:
+        print 'Monkey-patching usb.util.get_string()'
+        def get_string(dev, index, langid = None):
+            return usb.util.zzz__get_string(dev, 255, index, langid)
+        usb.util.zzz__get_string = usb.util.get_string
+        usb.util.get_string = get_string
+
+if USBVER == 1:
+    pyusb_1x_patch()


### PR DESCRIPTION
This fixes issues regarding changed APIs in PyUSB (1.0.0b2 and later).

I've tested (using zbstumbler and RZUSBSTICK) on 1.0.0b1 (walac/pyusb@0546cad),  1.0.0b2 (walac/pyusb@80f81ef), and the latest walac/pyusb@39816be.

This fixes everything I've encountered re: #37.