### PR TITLE
gps drift fix

### DIFF
--- a/killerbee/zbwardrive/__init__.py
+++ b/killerbee/zbwardrive/__init__.py
@@ -5,6 +5,6 @@
 from killerbee import *
 from db import *
 from scanning import doScan
-from zbwardrive import startScan
+from zbwardrive import startScan, gpsdPoller
 from capture import *
 

--- a/killerbee/zbwardrive/zbwardrive.py
+++ b/killerbee/zbwardrive/zbwardrive.py
@@ -11,8 +11,6 @@ from killerbee import KillerBee, kbutils
 from db import ZBScanDB
 from scanning import doScan
 
-GPS_FREQUENCY=3 #in seconds
-
 # GPS Poller
 def gpsdPoller(currentGPS):
     '''
@@ -42,7 +40,6 @@ def gpsdPoller(currentGPS):
             else:
                 print "Waiting for a GPS fix."
                 #TODO timeout lat/lng/alt values if too old...?
-            sleep(GPS_FREQUENCY)
     except KeyboardInterrupt:
         print "Got KeyboardInterrupt in gpsdPoller, returning."
         return


### PR DESCRIPTION
GPSD's poll continually reads and sends updates. Waiting 3 seconds (or any set amount) creates a drift with the GPS coordinates causing later pcaps to be associated with earlier GPS coordinates.