### PR TITLE
Cleanup zbwireshark and other improvements / bugfixes

### DIFF
--- a/killerbee/__init__.py
+++ b/killerbee/__init__.py
@@ -41,9 +41,10 @@ def show_dev(vendor=None, product=None, gps=None, include=None):
     @param include: Provide device names in this argument if you would like only
         these to be enumerated. Aka, include only these items.
     '''
-    print("{: >14} {: <20} {: >10}".format("Dev", "Product String", "Serial Number"))
+    fmt = "{: >14} {: <20} {: >10}"
+    print(fmt.format("Dev", "Product String", "Serial Number"))
     for dev in kbutils.devlist(vendor=vendor, product=product, gps=gps, include=include):
-        print("{0: >14} {1: <20} {2: >10}".format(dev[0], dev[1], dev[2]))
+        print(fmt.format(dev[0], dev[1], dev[2]))
 
 # KillerBee Class
 class KillerBee:

--- a/killerbee/__init__.py
+++ b/killerbee/__init__.py
@@ -259,6 +259,8 @@ class KillerBee:
         @param channel: Sets the channel, optional
         @rtype: None
         '''
+        if not self.is_valid_channel(channel):
+            raise ValueError('Invalid channel ({0}) for this device'.format(channel))
         if hasattr(self, "dblog"):
             self.dblog.set_channel(channel)
         self.driver.set_channel(channel)

--- a/killerbee/__init__.py
+++ b/killerbee/__init__.py
@@ -256,13 +256,6 @@ class KillerBee:
             self.dblog.set_channel(channel)
         self.driver.set_channel(channel)
 
-    def is_valid_channel(self, channel):
-        '''
-        Based on sniffer capabilities, return if this is an OK channel number.
-        @rtype: Boolean
-        '''
-        return self.driver.capabilities.is_valid_channel(channel)
-
     def inject(self, packet, channel=None, count=1, delay=0):
         '''
         Injects the specified packet contents.

--- a/killerbee/__init__.py
+++ b/killerbee/__init__.py
@@ -165,6 +165,13 @@ class KillerBee:
                 warn("Error initializing DBLogger (%s)." % e)
                 datasource = None   #give up nicely if error connecting, etc.
 
+    # Allow 'with KillerBee(...) as kb:' syntax
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exinfo):
+        self.close()
+
     def __device_is(self, vendorId, productId):
         '''
         Compares KillerBee class' device data to a known USB vendorId and productId

--- a/killerbee/kbutils.py
+++ b/killerbee/kbutils.py
@@ -78,9 +78,9 @@ class KBCapabilities:
         Based on sniffer capabilities, return if this is an OK channel number.
         @rtype: Boolean
         '''
-        if (channel >= 11 or channel <= 26) and self.check(self.FREQ_2400):
+        if (channel >= 11 and channel <= 26) and self.check(self.FREQ_2400):
             return True
-        elif (channel >= 1 or channel <= 10) and self.check(self.FREQ_900):
+        elif (channel >= 1 and channel <= 10) and self.check(self.FREQ_900):
             return True
         return False
 

--- a/killerbee/pcapdump.py
+++ b/killerbee/pcapdump.py
@@ -108,13 +108,20 @@ class PcapDumper:
         Creates a libpcap file using the specified datalink type.
         @type datalink: Integer
         @param datalink: Datalink type, one of DLT_* defined in pcap-bpf.h
-        @type savefile: String
-        @param savefile: Output libpcap filename to open
+        @type savefile: String or file-like object
+        @param savefile: Output libpcap filename to open, or file-like object
         @rtype: None
         '''
         if ppi: from killerbee.pcapdlt import DLT_PPI
         self.ppi = ppi
-        self.__fh = open(savefile, mode='wb')
+
+        if isinstance(savefile, basestring):
+            self.__fh = open(savefile, mode='wb')
+        elif hasattr(savefile, 'write'):
+            self.__fh = savefile
+        else:
+            raise ValueError("Unsupported type for 'savefile' argument")
+
         self.datalink = datalink
         self.__fh.write(''.join([
             struct.pack("I", PCAPH_MAGIC_NUM), 

--- a/killerbee/pcapdump.py
+++ b/killerbee/pcapdump.py
@@ -126,6 +126,12 @@ class PcapDumper:
             struct.pack("I", DLT_PPI if self.ppi else self.datalink)
             ]))
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exinfo):
+        self.close()
+
     def pcap_dump(self, packet, ts_sec=None, ts_usec=None, orig_len=None, 
                   freq_mhz = None, ant_dbm = None, location = None):
         '''
@@ -249,8 +255,6 @@ class PcapDumper:
             self.__fh.flush()
         except IOError, e:
             raise e
-
-        return
 
 
     def close(self):

--- a/killerbee/pcapdump.py
+++ b/killerbee/pcapdump.py
@@ -110,6 +110,8 @@ class PcapDumper:
         @param datalink: Datalink type, one of DLT_* defined in pcap-bpf.h
         @type savefile: String or file-like object
         @param savefile: Output libpcap filename to open, or file-like object
+        @type ppi: Boolean
+        @param ppi: Include CACE Per-Packet Information (defaults to False)
         @rtype: None
         '''
         if ppi: from killerbee.pcapdlt import DLT_PPI

--- a/tools/zbwireshark
+++ b/tools/zbwireshark
@@ -24,7 +24,8 @@ def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-i', '--iface', '--dev', action='store', dest='devstring',
             help='Device to use for sniffing')
-    parser.add_argument('-p', '--ppi', action='store_true')
+    parser.add_argument('-p', '--ppi', action='store_true',
+            help='Include CACE Per-Packet Information in PCAP')
     parser.add_argument('-c', '-f', '--channel', action='store', type=int, required=True,
             help='Channel on which to sniff')
     parser.add_argument('-n', '--count', action='store', type=int, default=None,

--- a/tools/zbwireshark
+++ b/tools/zbwireshark
@@ -21,7 +21,7 @@ def main():
     #parser.add_argument('-g', '--gps', '--ignore', action='append', dest='ignore')
     parser.add_argument('-p', '--ppi', action='store_true')
     parser.add_argument('-c', '-f', '--channel', action='store', type=int, default=None)
-    parser.add_argument('-n', '--count', action='store', default=None)
+    parser.add_argument('-n', '--count', action='store', type=int, default=None)
     parser.add_argument('-D', action='store_true', dest='showdev')
     args = parser.parse_args()
 

--- a/tools/zbwireshark
+++ b/tools/zbwireshark
@@ -17,12 +17,15 @@ def main():
 
     # Command-line arguments
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('-i', '--iface', '--dev', action='store', dest='devstring')
-    #parser.add_argument('-g', '--gps', '--ignore', action='append', dest='ignore')
+    parser.add_argument('-i', '--iface', '--dev', action='store', dest='devstring',
+            help='Device to use for sniffing')
     parser.add_argument('-p', '--ppi', action='store_true')
-    parser.add_argument('-c', '-f', '--channel', action='store', type=int, default=None)
-    parser.add_argument('-n', '--count', action='store', type=int, default=None)
-    parser.add_argument('-D', action='store_true', dest='showdev')
+    parser.add_argument('-c', '-f', '--channel', action='store', type=int, required=True,
+            help='Channel on which to sniff')
+    parser.add_argument('-n', '--count', action='store', type=int, default=None,
+            metavar='COUNT', help='Limit capture to COUNT packets')
+    parser.add_argument('-D', action='store_true', dest='showdev',
+            help='Show device info and exit')
     args = parser.parse_args()
 
     if args.showdev:

--- a/tools/zbwireshark
+++ b/tools/zbwireshark
@@ -34,6 +34,23 @@ def parse_args():
             help='Show device info and exit')
     args = parser.parse_args()
 
+def start_wireshark():
+    spargs = dict(
+        args = ['wireshark','-k','-i','-'],    # Read packets from stdin immediately
+        stdin = subprocess.PIPE,
+        stderr = open(os.devnull, 'w'),
+    )
+
+    # Put Wireshark in its own process group.
+    # On *nix, this is necessary to keep Wireshark open after this script exists.
+    # It doesn't appear to be necessary on Windows to accomplish the same,
+    # but seems like a good idea to take the equivalent action on both platforms..
+    if os.name == 'posix':
+        spargs['preexec_fn'] = os.setpgrp
+    elif os.name == 'nt':
+        spargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
+
+    return subprocess.Popen(**spargs)
 
 def main():
     parse_args()
@@ -49,12 +66,7 @@ def main():
         kb.sniffer_on()
 
         # Start Wireshark
-        wireshark_proc = subprocess.Popen(
-                ['wireshark','-k','-i','-'],    # Read packets from stdin immediately
-                stdin = subprocess.PIPE,
-                stderr = open(os.devnull, 'w'),
-                preexec_fn = os.setpgrp,        # Own process group; stay open after we exit
-                )
+        wireshark_proc = start_wireshark()
 
         # Create a PCAP dumper to write packets to wireshark
         with PcapDumper(DLT_IEEE802_15_4, wireshark_proc.stdin, ppi=args.ppi) as pd:

--- a/tools/zbwireshark
+++ b/tools/zbwireshark
@@ -13,7 +13,8 @@ import subprocess
 from killerbee import *
 
 
-def main():
+def parse_args():
+    global args
 
     # Command-line arguments
     parser = argparse.ArgumentParser(description=__doc__)
@@ -27,6 +28,10 @@ def main():
     parser.add_argument('-D', action='store_true', dest='showdev',
             help='Show device info and exit')
     args = parser.parse_args()
+
+
+def main():
+    parse_args()
 
     if args.showdev:
         show_dev()

--- a/tools/zbwireshark
+++ b/tools/zbwireshark
@@ -6,92 +6,78 @@ Sends sniffed IEEE 802.15.4 packets to Wireshark via a named pipe.
 '''
 
 import sys
-import signal
-import os, tempfile
+import os
 import argparse
+import subprocess
 
 from killerbee import *
 
-def interrupt(signum, frame):
-    global packetcount
-    global kb
-    global pd
-    global pipefname
-    global tempdir
-    kb.sniffer_off()
-    kb.close()
-    pd.close()
-    os.remove(pipefname)
-    os.rmdir(tempdir)
-    print("{0} packets captured".format(packetcount))
-    sys.exit(0)
 
-pipename = 'zbwireshark'
+def main():
 
-# Global
-packetcount = 0
+    # Command-line arguments
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('-i', '--iface', '--dev', action='store', dest='devstring')
+    #parser.add_argument('-g', '--gps', '--ignore', action='append', dest='ignore')
+    parser.add_argument('-p', '--ppi', action='store_true')
+    parser.add_argument('-c', '-f', '--channel', action='store', type=int, default=None)
+    parser.add_argument('-n', '--count', action='store', default=None)
+    parser.add_argument('-D', action='store_true', dest='showdev')
+    args = parser.parse_args()
 
-# Command-line arguments
-parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument('-i', '--iface', '--dev', action='store', dest='devstring')
-#parser.add_argument('-g', '--gps', '--ignore', action='append', dest='ignore')
-parser.add_argument('-p', '--ppi', action='store_true')
-parser.add_argument('-c', '-f', '--channel', action='store', type=int, default=None)
-parser.add_argument('-n', '--count', action='store', default=None)
-parser.add_argument('-D', action='store_true', dest='showdev')
-args = parser.parse_args()
+    if args.showdev:
+        show_dev()
+        sys.exit(0)
 
-if args.showdev:
-    show_dev()
-    sys.exit(0)
- 
-if args.channel == None:
-    print >>sys.stderr, "ERROR: Must specify a channel."
-    sys.exit(1)
+    # Start KillerBee
+    with KillerBee(device=args.devstring) as kb:
+        try:
+            kb.set_channel(args.channel)
+        except ValueError as e:
+            print 'ERROR:', e
+            sys.exit(1)
 
-# Make FIFO (named pipe)
-tempdir = tempfile.mkdtemp()
-pipefname = os.path.join(tempdir, pipename)
-try:
-    os.mkfifo(pipefname) #default mode 0666 (octal)
-except OSError, e:
-    print("Failed to create FIFO: {0}".format(e))
-    sys.exit(-1)
+        kb.sniffer_on()
 
-# Start KillerBee
-kb = KillerBee(device=args.devstring)
-signal.signal(signal.SIGINT, interrupt)
-if not kb.is_valid_channel(args.channel):
-    print >>sys.stderr, "ERROR: Must specify a valid IEEE 802.15.4 channel for the selected device."
-    kb.close()
-    sys.exit(1)
-kb.set_channel(args.channel)
-kb.sniffer_on()
+        # Start Wireshark
+        wireshark_proc = subprocess.Popen(
+                ['wireshark','-k','-i','-'],    # Read packets from stdin immediately
+                stdin = subprocess.PIPE,
+                stderr = open(os.devnull, 'w'),
+                preexec_fn = os.setpgrp,        # Own process group; stay open after we exit
+                )
 
-# Start wireshark as soon as KillerBee succeeds
-try:
-    rc = os.fork()
-    if rc == 0:
-        os.execlp("wireshark", "/usr/bin/wireshark", "-k", "-i", pipefname)
-except OSError, e:
-    print("Failed to automatically spawn wireshark: {0}".format(e))
-    print("You should manually point Wireshark to read from the pipe file: {0}".format(pipefname))
+        # Create a PCAP dumper to write packets to wireshark
+        with PcapDumper(DLT_IEEE802_15_4, wireshark_proc.stdin, ppi=args.ppi) as pd:
 
-pd = PcapDumper(DLT_IEEE802_15_4, pipefname, ppi=args.ppi)
-rf_freq_mhz = (args.channel - 10) * 5 + 2400
-print("zbwireshark: listening on \'{0}\', sending to \'{1}\'".format(kb.get_dev_info()[0], pipefname))
+            rf_freq_mhz = (args.channel - 10) * 5 + 2400
+            print("zbwireshark: listening on \'{0}\'".format(kb.get_dev_info()[0]))
 
-try:
-    while args.count != packetcount:
-        packet = kb.pnext()
-        if packet != None:
-            packetcount+=1
-            pd.pcap_dump(packet['bytes'], ant_dbm=packet['dbm'], freq_mhz=rf_freq_mhz)
-except KeyboardInterrupt:
-    pass
-except IOError as e:
-    if e.errno == 32:
-        print("ERROR: Pipe broken. Was Wireshark closed or stopped?")
+            try:
+                packetcount = 0
+                while args.count != packetcount:
+                    # Wait for the next packet
+                    packet = kb.pnext()
 
-interrupt(0, 0) #shutdown and exit
+                    rc = wireshark_proc.poll()
+                    if rc is not None:
+                        print("Wireshark exited ({0})".format(rc))
+                        break
 
+                    if packet != None:
+                        packetcount+=1
+                        pd.pcap_dump(packet['bytes'], ant_dbm=packet['dbm'], freq_mhz=rf_freq_mhz)
+
+            except KeyboardInterrupt:
+                pass
+            except IOError as e:
+                if e.errno == 32:
+                    #print("ERROR: Pipe broken. Was Wireshark closed or stopped?")
+                    pass
+                else:
+                    raise
+
+            print("{0} packets captured".format(packetcount))
+
+if __name__ == '__main__':
+    main()

--- a/tools/zbwireshark
+++ b/tools/zbwireshark
@@ -12,6 +12,10 @@ import subprocess
 
 from killerbee import *
 
+class ShowDevAction(argparse.Action):
+    def __call__(self, *a, **kw):
+        show_dev()
+        sys.exit(0)
 
 def parse_args():
     global args
@@ -25,17 +29,13 @@ def parse_args():
             help='Channel on which to sniff')
     parser.add_argument('-n', '--count', action='store', type=int, default=None,
             metavar='COUNT', help='Limit capture to COUNT packets')
-    parser.add_argument('-D', action='store_true', dest='showdev',
+    parser.add_argument('-D', action = ShowDevAction, nargs=0,
             help='Show device info and exit')
     args = parser.parse_args()
 
 
 def main():
     parse_args()
-
-    if args.showdev:
-        show_dev()
-        sys.exit(0)
 
     # Start KillerBee
     with KillerBee(device=args.devstring) as kb:


### PR DESCRIPTION
I performed a substantial refactoring of `zbwireshark`, namely in the exit/cleanup department.

- Use `with` statements to handle automatic cleanup upon receipt of `KeyboardInterrupt`, instead of manually registering a signal handler.
    - This required adding the context manager `__enter__` / `__exit__` APIs to `KillerBee` and `PcapDumper` classes
- Pass PCAP data to Wireshark via its `stdin` instead of opening a named pipe
    - Simpler, less cleanup, just as functional
    - This required overloading the `savefile` argument to `PcapDumper.__init__()`, allowing it to take a file handle *or* a filename
- Wireshark `stderr` sent to `/dev/null`, silencing all of the annoying GTK warnings
- Overall more "Pythonic"

Also fixed several bugs discovered along the way:
- `--count` / `-n` option to `zbwireshark` was not actually doing anything
- `KillerBee.is_valid_channel()` was duplicated
- `KBCapabilities.is_valid_channel()` channel range logic was incorrect

The `zbwireshark` refactoring depends on the commits to `PcapDumper` and `KillerBee` of course, so I decided to make this all one PR.  The commits should be pretty isolated and concise, however.  Let me know if you need me to split it up.