### PR TITLE
Fix #62, update reserved2 to nwk_seclevel

### DIFF
--- a/killerbee/scapy_extensions.py
+++ b/killerbee/scapy_extensions.py
@@ -124,7 +124,7 @@ def kbsendp(pkt, channel = None, inter = 0, loop = 0, iface = None, count = None
     # Make sure the packet has 2 bytes for FCS before TX
     if not pkt.haslayer(Dot15d4FCS):
         pkt/=Raw("\x00\x00")
-    
+
     pkts_out = __kb_send(kb, pkt, inter = inter, loop = loop, count = count, verbose = verbose, realtime = realtime)
     print "\nSent %i packets." % pkts_out
 
@@ -159,11 +159,11 @@ def kbsrp(pkt, channel = None, inter = 0, count = 0, iface = None, store = 1, pr
         kb.set_channel(channel)
     else:
         kb = iface
-    
+
     # Make sure the packet has an FCS layer before TX
     if not pkt.haslayer(Dot15d4FCS):
         pkt/=Raw("\x00\x00")
-    
+
     pkts_out = __kb_send(kb, pkt, inter = inter, loop = 0, count = None, verbose = verbose, realtime = realtime)
     if verbose:
         print "\nSent %i packets." % pkts_out
@@ -178,7 +178,7 @@ def kbsrp1(pkt, channel = None, inter = 0, iface = None, store = 1, prn = None, 
     """Send and receive packets with KillerBee and return only the first answer"""
     return kbsrp(pkt, channel = channel, inter = inter, count = 1, iface = iface, store = store, prn = prn, lfilter = lfilter, timeout = timeout, verbose = verbose, realtime = realtime)
 
-@conf.commands.register 
+@conf.commands.register
 def kbsniff(channel = None, count = 0, iface = None, store = 1, prn = None, lfilter = None, stop_filter = None, verbose = None, timeout = None):
     """
     Sniff packets with KillerBee.
@@ -443,7 +443,7 @@ def kbdecrypt(pkt, key = None, verbose = None):
         print "\tNonce:          " + nonce.encode('hex')
         print "\tMic:            " + mic.encode('hex')
         print "\tEncrypted Data: " + encrypted.encode('hex')
-    
+
     crop_size = 4 + 2 + len(pkt.getlayer(ZigbeeSecurityHeader).fields['data'])  # the size of all the zigbee crap, minus the length of the encrypted data, mic and FCS
 
     # the Security Control Field flags have to be adjusted before this is calculated, so we store their original values so we can reset them later
@@ -452,7 +452,7 @@ def kbdecrypt(pkt, key = None, verbose = None):
     zigbeeData = pkt.getlayer(ZigbeeNWK).do_build()
     zigbeeData = zigbeeData[:-crop_size]
     #pkt.getlayer(ZigbeeSecurityHeader).fields['reserved2'] = reserved2
-    
+
     (payload, micCheck) = zigbee_crypt.decrypt_ccm(key, nonce, mic, encrypted, zigbeeData)
 
     if verbose > 2:
@@ -494,7 +494,7 @@ def kbencrypt(pkt, data, key = None, verbose = None):
 
     f = pkt.getlayer(ZigbeeSecurityHeader).fields
     f['data'] = ''  # explicitly clear it out, this should go without say
-    
+
     if isinstance(data, Packet):
         decrypted = data.do_build()
     else:
@@ -503,7 +503,7 @@ def kbencrypt(pkt, data, key = None, verbose = None):
     nonce = ""  # build the nonce
     nonce += struct.pack(">Q", f['source'])
     nonce += struct.pack(">I", f['fc'])
-    fc = (f['reserved1'] << 6) | (f['extended_nonce'] << 5) | (f['key_type'] << 3) | f['reserved2']
+    fc = (f['reserved1'] << 6) | (f['extended_nonce'] << 5) | (f['key_type'] << 3) | f['nwk_seclevel']
     nonce += chr(fc | 0x05)
 
     if verbose > 2:
@@ -511,22 +511,22 @@ def kbencrypt(pkt, data, key = None, verbose = None):
         print "\tKey:            " + key.encode('hex')
         print "\tNonce:          " + nonce.encode('hex')
         print "\tDecrypted Data: " + decrypted.encode('hex')
-        
+
     crop_size = 4 + 2 # the size of all the zigbee crap, minus the length of the mic and FCS
-    
+
     # the Security Control Field flags have to be adjusted before this is calculated, so we store their original values so we can reset them later
     reserved2 = pkt.getlayer(ZigbeeSecurityHeader).fields['reserved2']
     pkt.getlayer(ZigbeeSecurityHeader).fields['reserved2'] = (pkt.getlayer(ZigbeeSecurityHeader).fields['reserved2'] | 0x05)
     zigbeeData = pkt.getlayer(ZigbeeNWK).do_build()
     zigbeeData = zigbeeData[:-crop_size]
     pkt.getlayer(ZigbeeSecurityHeader).fields['reserved2'] = reserved2
-    
+
     (payload, mic) = zigbee_crypt.encrypt_ccm(key, nonce, 4, decrypted, zigbeeData)
 
     if verbose > 2:
         print "\tEncrypted Data: " + payload.encode('hex')
         print "\tMic:            " + mic.encode('hex')
-    
+
     # Set pkt's values to reflect the encrypted ones to it's ready to be sent
     f['data'] = payload
     f['mic'] = struct.unpack(">I", mic)[0]


### PR DESCRIPTION
Fix issue #62 by updating the ZigbeeSecurityHeader.reserved2 field to nwk_seclevel to reflect changes introduced in the upstream scapy-com repository. See [the diff](https://bitbucket.org/secdev/scapy-com/diff/scapy/layers/dot15d4.py?diff2=437f5fe62c32&at=default) for details.