### PR TITLE
Pyserial v2/3 upgrade

### DIFF
--- a/killerbee/GoodFET.py
+++ b/killerbee/GoodFET.py
@@ -198,7 +198,7 @@ class GoodFET:
                     return
                 elif attempts==2 and os.environ.get("board")!='telosb':
                     print "See the GoodFET FAQ about missing info flash.";
-                    self.serialport.setTimeout(0.2);
+                    self.serialport.timeout = 0.2;
                 elif attempts == 100:
 		    print "Tried 100 times to connect and failed."
 		    sys.stdout.write("Continuing to try forever.")	# No newline
@@ -262,7 +262,7 @@ class GoodFET:
                     break;
         if self.verbose: print "Connected after %02i attempts." % attempts;
         self.mon_connected();
-        self.serialport.setTimeout(12);
+        self.serialport.timeout = 12;
     def serClose(self):
         self.serialport.close();
 
@@ -643,7 +643,7 @@ class GoodFET:
         self.serialport.write(chr(baud));
         
         print "Changed host baud."
-        self.serialport.setBaudrate(rates[baud]);
+        self.serialport.baudrate = rates[baud];
         time.sleep(1);
         self.serialport.flushInput()
         self.serialport.flushOutput()
@@ -655,7 +655,7 @@ class GoodFET:
     def findbaud(self):
         for r in self.baudrates:
             print "\nTrying %i" % r;
-            self.serialport.setBaudrate(r);
+            self.serialport.baudrate = r;
             #time.sleep(1);
             self.serialport.flushInput()
             self.serialport.flushOutput()

--- a/killerbee/GoodFETatmel128.py
+++ b/killerbee/GoodFETatmel128.py
@@ -97,7 +97,7 @@ class GoodFETatmel128rfa1(GoodFETAVR):
                         break
             if self.verbose:
                 print "Connected after %02i attempts." % attempts;
-            self.serialport.setTimeout(12);
+            self.serialport.timeout = 12;
 
     def serClose(self):
         self.connected = 0

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup  (name        = 'killerbee',
                    'tools/zbfind', 'tools/zbscapy', 'tools/zbwireshark', 'tools/zbkey', 
                     'tools/zbwardrive', 'tools/zbopenear', 'tools/zbfakebeacon', 
                     'tools/zborphannotify', 'tools/zbpanidconflictflood', 'tools/zbrealign'],
-        install_requires=['pyserial', 'pyusb', 'crypto'],
+        install_requires=['pyserial>=2.0', 'pyusb', 'crypto'],
         ext_modules = [ zigbee_crypt ],
         )
 


### PR DESCRIPTION
Upgrade pyserial function calls in order to use the pyserial v2 and v3 API. According to https://github.com/pyserial/pyserial/issues/66, the pyserial v1 API, which is used currently, is deprecated since 12 years, so it should be safe to upgrade.

The pyserial v1 api was still supported in pyserial v2 but was depricated, it was completely removed in pyserial v3. Therefore, it does not work anymore with newer pyserial versions.

This fixes the problem described in the issue "pyserial 3 errors" #78.