### PR TITLE
Fix RZUSBStick capture stalling on 64 byte packets

### DIFF
--- a/firmware/src/kb-rzusbstick/application/rzusbstick/air_capture.c
+++ b/firmware/src/kb-rzusbstick/application/rzusbstick/air_capture.c
@@ -265,6 +265,7 @@ void air_capture_task(void) {
             } else if (1 == packets_left) {
                 /* Send Zero Length Packet and then update tail pointer. */
                 UEINTX &= ~(1 << FIFOCON);
+                packets_left = 0;
                 
                 /* Update FIFO tail. */
                 ENTER_CRITICAL_REGION();


### PR DESCRIPTION
There was a bug in the RZUSBStick firmware handling of USB
bulk transfers of exactly 64 bytes.  When performing bulk
transfer over USB of more than the individual bulk transfer
frame size (64 bytes), then the bulk transfer must be sent
as multiple frames of 64 bytes followed by a short frame.
If the data is an exact multiple of 64 bytes then the final
transaction must be zero length.  The RZUSBStick firmware
failed to reset its 'packets_left' count to zero when
sending a final zero length frame, resulting in the
firmware constantly sending zero length frames due to
'packets_left' becoming stuck at '1' with no data to send.

This fix resets 'packets_left' to 0 when sending a zero
length frame.

Also note that this bug appears to exist in the original
Atmel firmware (the bug can be demonstrated using the Atmel
firmware, and this area of code has not otherwise been
modified for KillerBee).