### PR TITLE
Add support for CC2530/1 USB dongles for sniffing.

### DIFF
--- a/killerbee/__init__.py
+++ b/killerbee/__init__.py
@@ -111,6 +111,12 @@ class KillerBee:
                     self.driver = RZUSBSTICK(self.dev, self.__bus)
                 elif self.__device_is(ZN_USB_VEND_ID, ZN_USB_PROD_ID):
                     raise KBInterfaceError("Zena firmware not yet implemented.")
+                elif self.__device_is(CC2530_USB_VEND_ID, CC2530_USB_PROD_ID):
+                    from dev_cc253x import CC253x
+                    self.driver = CC253x(self.dev, self.__bus, CC253x.VARIANT_CC2530)
+                elif self.__device_is(CC2531_USB_VEND_ID, CC2531_USB_PROD_ID):
+                    from dev_cc253x import CC253x
+                    self.driver = CC253x(self.dev, self.__bus, CC253x.VARIANT_CC2531)
                 else:
                     raise KBInterfaceError("KillerBee doesn't know how to interact with USB device vendor=%04x, product=%04x.".format(self.dev.idVendor, self.dev.idProduct))
 

--- a/killerbee/dev_cc253x.py
+++ b/killerbee/dev_cc253x.py
@@ -1,0 +1,272 @@
+'''
+CC253x support is contributed by Scytmo.
+'''
+
+# Import USB support depending on version of pyUSB
+try:
+    import usb.core
+    import usb.util
+    import sys
+    print >>sys.stderr, "Warning: You are using pyUSB 1.x, support is in beta."
+except ImportError:
+    import usb
+    print >>sys.stderr, "Error: You are using pyUSB 0.x, not supported for CC253x."
+    sys.exit()
+
+import struct
+import time
+from datetime import datetime
+from kbutils import KBCapabilities
+
+
+class CC253x:
+    USB_DIR_OUT        = 0x40
+    USB_DIR_IN         = 0xC0
+    USB_POWER_ON       = 0xC5
+    USB_POWER_STATUS   = 0xC6
+    USB_XFER_START     = 0xD0
+    USB_XFER_STOP      = 0xD1
+    USB_XFER_CHAN      = 0xD2
+    USB_CC2530_DATA_EP = 0x82
+    USB_CC2531_DATA_EP = 0x83
+
+    VARIANT_CC2530 = 0
+    VARIANT_CC2531 = 1
+
+    def __init__(self, dev, bus, variant):
+        #TODO deprecate bus param, and dev becomes a usb.core.Device object, not a string in pyUSB 1.x use
+        '''
+        Instantiates the KillerBee class for Zigduino running GoodFET firmware.
+        @type dev:   String
+        @param dev:  PyUSB device
+        @return: None
+        @rtype: None
+        '''
+        if variant == CC253x.VARIANT_CC2530:
+            self._data_ep = CC253x.USB_CC2530_DATA_EP
+        else:
+            self._data_ep = CC253x.USB_CC2531_DATA_EP
+        self._channel = None
+        self.dev = dev
+        self.name = "<unknown>"
+
+        self.__stream_open = False
+        self.capabilities = KBCapabilities()
+        self.__set_capabilities()
+
+        # Set default configuration
+        self.dev.set_configuration()
+
+        # get name from USB descriptor
+        self.name = usb.util.get_string(self.dev, self.dev.iProduct)
+
+        # Get wMaxPacketSize from the data endpoint
+        for cfg in self.dev:
+            for intf in cfg:
+                for ep in intf:
+                    if ep.bEndpointAddress == self._data_ep:
+                        self._maxPacketSize = ep.wMaxPacketSize
+
+
+    def close(self):
+        pass
+
+    def check_capability(self, capab):
+        return self.capabilities.check(capab)
+
+    def get_capabilities(self):
+        return self.capabilities.getlist()
+
+    def __set_capabilities(self):
+        '''
+        Sets the capability information appropriate for CC253x.
+        @rtype: None
+        @return: None
+        '''
+        self.capabilities.setcapab(KBCapabilities.FREQ_2400, True)
+        self.capabilities.setcapab(KBCapabilities.SNIFF, True)
+        self.capabilities.setcapab(KBCapabilities.SETCHAN, True)
+        #self.capabilities.setcapab(KBCapabilities.INJECT, True)
+        #self.capabilities.setcapab(KBCapabilities.PHYJAM_REFLEX, True)
+        #self.capabilities.setcapab(KBCapabilities.SET_SYNC, True)
+
+    # KillerBee expects the driver to implement this function
+    def get_dev_info(self):
+        '''
+        Returns device information in a list identifying the device.
+        @rtype: List
+        @return: List of 3 strings identifying device.
+        '''
+        return [self.name, "CC253x", ""]
+
+    # KillerBee expects the driver to implement this function
+    def sniffer_on(self, channel=None):
+        '''
+        Turns the sniffer on such that pnext() will start returning observed
+        data.  Will set the command mode to Air Capture if it is not already
+        set.
+        @type channel: Integer
+        @param channel: Sets the channel, optional
+        @rtype: None
+        '''
+        self.capabilities.require(KBCapabilities.SNIFF)
+
+        if channel != None:
+            self.set_channel(channel)
+
+        # Enable power in 802.15.4 radio
+        self.dev.ctrl_transfer(CC253x.USB_DIR_OUT, CC253x.USB_POWER_ON, wIndex = 4)
+        while True:
+            # check if powered up
+            power_status = self.dev.ctrl_transfer(CC253x.USB_DIR_IN, CC253x.USB_POWER_STATUS, data_or_wLength = 1)
+            if power_status[0] == 4:
+                break
+            time.sleep(0.1)
+
+        # Set channel
+        self.dev.ctrl_transfer(CC253x.USB_DIR_OUT, CC253x.USB_XFER_CHAN, wIndex = 0, data_or_wLength = [self._channel])
+        self.dev.ctrl_transfer(CC253x.USB_DIR_OUT, CC253x.USB_XFER_CHAN, wIndex = 1, data_or_wLength = [0x00])
+
+        # Start capture
+        self.dev.ctrl_transfer(CC253x.USB_DIR_OUT, CC253x.USB_XFER_START)
+        self.__stream_open = True
+
+    # KillerBee expects the driver to implement this function
+    def sniffer_off(self):
+        '''
+        Turns the sniffer off, freeing the hardware for other functions.  It is
+        not necessary to call this function before closing the interface with
+        close().
+        @rtype: None
+        '''
+        self.dev.ctrl_transfer(CC253x.USB_DIR_OUT, CC253x.USB_XFER_STOP)
+        self.__stream_open = False
+
+    # KillerBee expects the driver to implement this function
+    def set_channel(self, channel):
+        '''
+        Sets the radio interface to the specifid channel (limited to 2.4 GHz channels 11-26)
+        @type channel: Integer
+        @param channel: Sets the channel, optional
+        @rtype: None
+        '''
+        self.capabilities.require(KBCapabilities.SETCHAN)
+
+        if channel >= 11 or channel <= 26:
+            self._channel = channel
+        else:
+            raise Exception('Invalid channel')
+
+    # KillerBee expects the driver to implement this function
+    def inject(self, packet, channel=None, count=1, delay=0):
+        '''
+        Injects the specified packet contents.
+        @type packet: String
+        @param packet: Packet contents to transmit, without FCS.
+        @type channel: Integer
+        @param channel: Sets the channel, optional
+        @type count: Integer
+        @param count: Transmits a specified number of frames, def=1
+        @type delay: Float
+        @param delay: Delay between each frame, def=1
+        @rtype: None
+        '''
+        raise Exception('Not yet implemented')
+
+    # KillerBee expects the driver to implement this function
+    def pnext(self, timeout=100):
+        '''
+        Returns a dictionary containing packet data, else None.
+        @type timeout: Integer
+        @param timeout: Timeout to wait for packet reception in usec
+        @rtype: List
+        @return: Returns None is timeout expires and no packet received.  When a packet is received, a dictionary is returned with the keys bytes (string of packet bytes), validcrc (boolean if a vaid CRC), rssi (unscaled RSSI), and location (may be set to None). For backwards compatibility, keys for 0,1,2 are provided such that it can be treated as if a list is returned, in the form [ String: packet contents | Bool: Valid CRC | Int: Unscaled RSSI ]
+        '''
+        if self.__stream_open == False:
+            self.sniffer_on() #start sniffing
+
+        ret = None
+        framedata = []
+        explen = 0 # expected remaining packet length
+        while True:
+            pdata = None
+            try:
+
+                pdata = self.dev.read(self._data_ep, self._maxPacketSize, timeout=timeout)
+            except usb.core.USBError as e:
+                if e.errno != 110: #Operation timed out
+                    print "Error args:", e.args
+                    raise e
+                    #TODO error handling enhancements for USB 1.0
+                else:
+                    return None
+
+            # Accumulate in 'framedata' until we have an entire frame
+            for byteval in pdata:
+                framedata.append(struct.pack("B", byteval))
+
+            if len(pdata) < 64:
+
+                if len(pdata) < 2:
+                    #print "ERROR: Very short frame"
+                    return None
+
+                framelen = ord(framedata[1])
+                if len(framedata) - 3 != framelen:
+                    #print "ERROR: Bad frame length: expected {0}, got {1}".format(framelen, len(framedata))
+                    return None
+
+                if framedata[0] != '\x00':
+                    #print "Not a capture frame:", framedata
+                    return None
+
+                payloadlen = ord(framedata[7]) # Includes TI format FCS
+                payload = framedata[8:]
+
+                if len(payload) != payloadlen:
+                    #print "ERROR: Bad payload length"
+                    return None
+
+                # See TI Smart RF User Guide for usage of 'CC24XX' format FCS fields
+                # in last two bytes of framedata
+
+                # RSSI is signed value, offset by 73 (see CC2530 data sheet for offset)
+                rssi = struct.unpack("b", framedata[-2])[0] - 73
+
+                fcsx = ord(framedata[-1])
+                # validcrc is the bit 7 in fcsx
+                validcrc  = (fcsx & 0x80) == 0x80
+                # correlation value is bits 0-6 in fcsx
+                correlation = fcsx & 0x7f
+
+                ret = {1:validcrc, 2:rssi, \
+                        'validcrc':validcrc, 'rssi':rssi, 'lqi':correlation,\
+                        'dbm':rssi,'datetime':datetime.utcnow()}
+
+                # Convert the framedata to a string for the return value
+                ret[0] = ''.join(payload)
+                ret['bytes'] = ret[0]
+                return ret
+
+
+    def jammer_on(self, channel=None):
+        '''
+        Not yet implemented.
+        @type channel: Integer
+        @param channel: Sets the channel, optional
+        @rtype: None
+        '''
+        raise Exception('Not yet implemented')
+
+    def set_sync(self, sync=0xA7):
+        '''Set the register controlling the 802.15.4 PHY sync byte.'''
+        raise Exception('Not yet implemented')
+
+    def jammer_off(self, channel=None):
+        '''
+        Not yet implemented.
+        @return: None
+        @rtype: None
+        '''
+        raise Exception('Not yet implemented')
+

--- a/killerbee/kbutils.py
+++ b/killerbee/kbutils.py
@@ -24,13 +24,17 @@ RZ_USB_VEND_ID      = 0x03EB
 RZ_USB_PROD_ID      = 0x210A
 ZN_USB_VEND_ID      = 0x04D8
 ZN_USB_PROD_ID      = 0x000E
+CC2530_USB_VEND_ID  = 0x11A0
+CC2530_USB_PROD_ID  = 0xEB20
+CC2531_USB_VEND_ID  = 0x0451
+CC2531_USB_PROD_ID  = 0x16AE
 #FTDI_USB_VEND_ID      = 0x0403
 #FTDI_USB_PROD_ID      = 0x6001 #this is also used by FDTI cables used to attach gps
 FTDI_X_USB_VEND_ID  = 0x0403
 FTDI_X_USB_PROD_ID  = 0x6015    #api-mote FTDI chip
 
-usbVendorList  = [RZ_USB_VEND_ID, ZN_USB_VEND_ID]
-usbProductList = [RZ_USB_PROD_ID, ZN_USB_PROD_ID]
+usbVendorList  = [RZ_USB_VEND_ID, ZN_USB_VEND_ID, CC2530_USB_VEND_ID, CC2531_USB_VEND_ID]
+usbProductList = [RZ_USB_PROD_ID, ZN_USB_PROD_ID, CC2530_USB_PROD_ID, CC2531_USB_PROD_ID]
 
 # Global variables
 gps_devstring = None


### PR DESCRIPTION
This adds support for packet sniffing for USB dongles based
on the TI CC2530 and CC2531 chips.

Note that the FCS received from these dongles is in TI CC24XX
format, so for wireshark to display the FCS information correctly,
the "TI CC24XX FCS format" in Preferences->Protocols->IEEE802.15.4
must be selected.