### PR TITLE
Standardize FCS on CC253x

### DIFF
--- a/killerbee/dev_apimote.py
+++ b/killerbee/dev_apimote.py
@@ -80,7 +80,7 @@ class APIMOTE:
 
     # KillerBee expects the driver to implement this function
     def get_dev_info(self):
-	'''
+        '''
         Returns device information in a list identifying the device.
         @rtype: List
         @return: List of 3 strings identifying device.
@@ -99,13 +99,13 @@ class APIMOTE:
         '''
         self.capabilities.require(KBCapabilities.SNIFF)
 
-        self.handle.RF_promiscuity(1);
-        self.handle.RF_autocrc(0);
+        self.handle.RF_promiscuity(1)
+        self.handle.RF_autocrc(0)
 
         if channel != None:
             self.set_channel(channel)
         
-        self.handle.CC_RFST_RX();
+        self.handle.CC_RFST_RX()
         #print "Sniffer started (listening as %010x on %i MHz)" % (self.handle.RF_getsmac(), self.handle.RF_getfreq()/10**6);
 
         self.__stream_open = True
@@ -178,9 +178,9 @@ class APIMOTE:
         @return: Returns None is timeout expires and no packet received.  When a packet is received, a dictionary is returned with the keys bytes (string of packet bytes), validcrc (boolean if a vaid CRC), rssi (unscaled RSSI), and location (may be set to None). For backwards compatibility, keys for 0,1,2 are provided such that it can be treated as if a list is returned, in the form [ String: packet contents | Bool: Valid CRC | Int: Unscaled RSSI ]
         '''
         if self.__stream_open == False:
-            self.sniffer_on() #start sniffing
+            self.sniffer_on()
 
-        packet = None;
+        packet = None
         start = datetime.utcnow()
 
         while (packet is None and (start + timedelta(microseconds=timeout) > datetime.utcnow())):
@@ -191,8 +191,9 @@ class APIMOTE:
             return None
 
         frame = packet[1:]
-        if frame[-2:] == makeFCS(frame[:-2]): validcrc = True
-        else: validcrc = False
+        validcrc = False
+        if frame[-2:] == makeFCS(frame[:-2]):
+            validcrc = True
         #Return in a nicer dictionary format, so we don't have to reference by number indicies.
         #Note that 0,1,2 indicies inserted twice for backwards compatibility.
         result = {0:frame, 1:validcrc, 2:rssi, 'bytes':frame, 'validcrc':validcrc, 'rssi':rssi, 'location':None}

--- a/killerbee/dev_cc253x.py
+++ b/killerbee/dev_cc253x.py
@@ -259,8 +259,9 @@ class CC253x:
                 # Convert the framedata to a string for the return value, and replace the TI FCS with a real FCS
                 # if the radio told us that the FCS had passed validation.
                 if validcrc:
-                    payload = payload[:-2] + makeFCS(payload[:-2])
-                ret[0] = ''.join(payload)
+                    ret[0] = ''.join(payload[:-2]) + makeFCS(payload[:-2])
+                else:
+                    ret[0] = ''.join(payload)
                 ret['bytes'] = ret[0]
                 return ret
 

--- a/killerbee/dev_cc253x.py
+++ b/killerbee/dev_cc253x.py
@@ -16,7 +16,7 @@ except ImportError:
 import struct
 import time
 from datetime import datetime
-from kbutils import KBCapabilities
+from kbutils import KBCapabilities, makeFCS
 
 
 class CC253x:
@@ -237,11 +237,11 @@ class CC253x:
                 payload = framedata[8:]
 
                 if len(payload) != payloadlen:
-                    #print "ERROR: Bad payload length"
+                    # TODO: Log "ERROR: Bad payload length"
                     return None
 
                 # See TI Smart RF User Guide for usage of 'CC24XX' format FCS fields
-                # in last two bytes of framedata
+                # in last two bytes of framedata. Note that we remove these before return of the frame.
 
                 # RSSI is signed value, offset by 73 (see CC2530 data sheet for offset)
                 rssi = struct.unpack("b", framedata[-2])[0] - 73
@@ -252,11 +252,14 @@ class CC253x:
                 # correlation value is bits 0-6 in fcsx
                 correlation = fcsx & 0x7f
 
-                ret = {1:validcrc, 2:rssi, \
-                        'validcrc':validcrc, 'rssi':rssi, 'lqi':correlation,\
+                ret = {1:validcrc, 2:rssi,
+                        'validcrc':validcrc, 'rssi':rssi, 'lqi':correlation,
                         'dbm':rssi,'datetime':datetime.utcnow()}
 
-                # Convert the framedata to a string for the return value
+                # Convert the framedata to a string for the return value, and replace the TI FCS with a real FCS
+                # if the radio told us that the FCS had passed validation.
+                if validcrc:
+                    payload = payload[:-2] + makeFCS(payload[:-2])
                 ret[0] = ''.join(payload)
                 ret['bytes'] = ret[0]
                 return ret

--- a/killerbee/dev_rzusbstick.py
+++ b/killerbee/dev_rzusbstick.py
@@ -447,10 +447,10 @@ class RZUSBSTICK:
             if USBVER == 0:
                 try:
                     pdata = self.handle.bulkRead(RZ_USB_PACKET_EP, timeout)
-                except usb.USBError, e:
+                except usb.USBError as e:
                     if e.args != ('No error',): # http://bugs.debian.org/476796
                         if e.args[0] != "Connection timed out": # USB timeout issue
-                            print "Error args:", e.args
+                            print("Error args: {}".format(e.args))
                             raise e
                         else:
                             return None
@@ -459,14 +459,14 @@ class RZUSBSTICK:
                     pdata = self.dev.read(RZ_USB_PACKET_EP, self.dev.bMaxPacketSize0, timeout=timeout)
                 except usb.core.USBError as e:
                     if e.errno != 110: #Operation timed out
-                        print "Error args:", e.args
+                        print("Error args: {}".format(e.args))
                         raise e
                         #TODO error handling enhancements for USB 1.0
                     else:
                         return None
 
             # PyUSB returns an empty tuple occasionally, handle as "no data"
-            #TODO added len(pdata) check as some arrays were failing
+            # NOTE: added len(pdata) check as some arrays were failing
             if pdata == None or pdata == () or len(pdata)==0:
                 return None
 
@@ -480,10 +480,10 @@ class RZUSBSTICK:
                     framedata.append(struct.pack("B", byteval))
                 #Return in a nicer dictionary format, so we don't have to reference by number indicies.
                 #Note that 0,1,2 indicies inserted twice for backwards compatibility.
-                ret = {1:validcrc, 2:rssi, \
-                        'validcrc':validcrc, 'rssi':rssi, \
+                ret = {1:validcrc, 2:rssi,
+                        'validcrc':validcrc, 'rssi':rssi,
                         'dbm':rssi,'datetime':datetime.utcnow()}
-                #TODO calculate dbm based on RSSI conversion formula for the chip
+                # TODO: calculate dbm based on RSSI conversion formula for the chip
             else:
                 if ret is not None:
                     # This is a continuation of a long AC packet, so append frame data
@@ -508,9 +508,8 @@ class RZUSBSTICK:
      
         def ping(self, da, panid, sa, channel=None):
             '''
-        Not yet implemented.
-        @return: None
-        @rtype: None
-        '''
-        raise Exception('Not yet implemented')
-
+            Not yet implemented.
+            @return: None
+            @rtype: None
+            '''
+            raise Exception('Not yet implemented')

--- a/killerbee/dev_sewio.py
+++ b/killerbee/dev_sewio.py
@@ -137,7 +137,7 @@ class SEWIO:
 
     # KillerBee expects the driver to implement this function
     def get_dev_info(self):
-	'''
+        '''
         Returns device information in a list identifying the device.
         @rtype: List
         @return: List of 3 strings identifying device.

--- a/killerbee/kbutils.py
+++ b/killerbee/kbutils.py
@@ -492,7 +492,7 @@ def makeFCS(data):
     crc = 0
     for i in xrange(len(data)):
         c = ord(data[i])
-		#if (A PARITY BIT EXISTS): c = c & 127	#Mask off any parity bit
+        #if (A PARITY BIT EXISTS): c = c & 127	#Mask off any parity bit
         q = (crc ^ c) & 15				#Do low-order 4 bits
         crc = (crc // 16) ^ (q * 4225)
         q = (crc ^ (c // 16)) & 15		#And high 4 bits


### PR DESCRIPTION
While most of this PR is just cleaning formatting, the content is a change in the CC253x driver to ensure that if the FCS is correct, than in the yielded packet we replace the TI fake-FCS with a real FCS like the other dev providers do.