### PR TITLE
Fixed output for zbstumbler -D

### DIFF
--- a/tools/zbstumbler
+++ b/tools/zbstumbler
@@ -114,13 +114,13 @@ if __name__ == '__main__':
     parser.add_argument('-g', '--gps', '--ignore', action='append', dest='ignore')
     parser.add_argument('-s', '--delay', action='store', type=float, dest='delay', default=2.0)
     parser.add_argument('-v', '--verbose', action='store_true')
-    parser.add_argument('-c', '--channel', action='store', type=int, default=None)
+    parser.add_argument('-c', '--channel', action='store', type=int, dest='channel', default=None)
     parser.add_argument('-w', '--file', action='store', dest='csvfile', default=None)
     parser.add_argument('-D', action='store_true', dest='showdev')
     args = parser.parse_args()
 
     if args.showdev:
-        show_dev()
+        show_dev(include=[args.devstring])
         sys.exit(0)
 
     if args.csvfile is not None:


### PR DESCRIPTION
before: just an empty output and exit
after the fix: show correct Product String and Serial Number