### PR TITLE
Add argument for is_valid_channel() function.

### DIFF
--- a/killerbee/dev_apimote.py
+++ b/killerbee/dev_apimote.py
@@ -198,10 +198,10 @@ class APIMOTE:
             return None
 
         frame = packet[1:]
-        '''
+        
         frame = frame[:-7]
         frame = frame + "\xff"
-        '''
+        
         validcrc = False
         if frame[-2:] == makeFCS(frame[:-2]):
             validcrc = True

--- a/killerbee/dev_apimote.py
+++ b/killerbee/dev_apimote.py
@@ -198,10 +198,8 @@ class APIMOTE:
             return None
 
         frame = packet[1:]
-        
         frame = frame[:-7]
         frame = frame + "\xff"
-        
         validcrc = False
         if frame[-2:] == makeFCS(frame[:-2]):
             validcrc = True

--- a/killerbee/dev_apimote.py
+++ b/killerbee/dev_apimote.py
@@ -198,9 +198,10 @@ class APIMOTE:
             return None
 
         frame = packet[1:]
+        '''
         frame = frame[:-7]
         frame = frame + "\xff"
-        
+        '''
         validcrc = False
         if frame[-2:] == makeFCS(frame[:-2]):
             validcrc = True

--- a/killerbee/dev_apimote.py
+++ b/killerbee/dev_apimote.py
@@ -198,6 +198,9 @@ class APIMOTE:
             return None
 
         frame = packet[1:]
+        frame = frame[:-7]
+        frame = frame + "\xff"
+        
         validcrc = False
         if frame[-2:] == makeFCS(frame[:-2]):
             validcrc = True

--- a/tools/zbjammer
+++ b/tools/zbjammer
@@ -25,6 +25,7 @@ parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('-i', '--iface', '--dev', action='store', dest='devstring')
 parser.add_argument('-c', '-f', '--channel', action='store', type=int, default=None)
 parser.add_argument('-D', action='store_true', dest='showdev')
+parser.add_argument('-s', '--subghz_page', action='store', type=int, default=0)
 args = parser.parse_args()
 
 if args.showdev:
@@ -37,7 +38,7 @@ if args.channel == None:
 
 kb = KillerBee(device=args.devstring)
 signal.signal(signal.SIGINT, interrupt)
-if not kb.is_valid_channel(args.channel):
+if not kb.is_valid_channel(args.channel, args.subghz_page):
     print >>sys.stderr, "ERROR: Must specify a valid IEEE 802.15.4 channel for the selected device."
     kb.close()
     sys.exit(1)

--- a/tools/zbkey
+++ b/tools/zbkey
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python\x00\x8
 
 import sys
 import signal
@@ -7,6 +7,17 @@ import struct
 import time
 
 from killerbee import *
+
+
+#Return bytes in the right format.
+def beautify(info):
+    info = repr(info).replace("\\x","")
+    info = info.replace("'","")
+    info = info[2:] + info[:2]
+    info = "0x" + info
+    return info 
+
+
 
 def usage():
     print >>sys.stderr, """
@@ -45,16 +56,15 @@ def associate_response_handle(packet):
             or none if the packet was not the length or type expected.
     '''
     print "Length of packet received in associate_handle: {0}".format(len(packet))
-    print kbutils.hexdump(packet)
-    if len(packet) > 24:
-        # Offset to Command Type, check to be 0x02 for assoc response type
-        if packet[21] == '\x02':
-            if packet[24] != '\x00':
-                print("Association response status was not successful. Received {0}.".format(struct.unpack('B', packet[24])[0]))
-                return None
-            # Offset to Response Assigned Short Addr (in assoc response type)
-            return packet[22:24] #device's short address, as binary string
-    return None   
+    try:
+        if packet[33] == '\x02':
+            print("test2")
+            short_addr = packet[34:36]
+            return short_addr
+        else:
+            return None 
+    except:
+        return None   
 
 
 def transport_response_handle(packet):
@@ -173,24 +183,20 @@ print "Sending data request packet..."
 #print kbutils.hexdump(data_assoc_packet)
 kb.inject(data_assoc_packet)
 
-# receiving the association response and setting the device_short_address
-value = None
-start = time.time()
-while (start+arg_delay > time.time()):		
-    # Does not block
+
+while True:
     recvpkt = kb.pnext()
-    # Check for empty packet (timeout) and valid FCS
-    if recvpkt != None and recvpkt['validcrc']:
-        print "Received frame"
-        # If packet is an assocation response, get the assigned device
-        # short address, else get None if packet isn't the right type
-        value = associate_response_handle(recvpkt['bytes'])
-        if value != None:
-            # Let's ack them to thank them for the join...
-            kb.sniffer_off()
-            kb.inject('\x02\x00'+getAckByte(recvpkt['bytes']))
-            print "Short address: {0}".format(value)
-            break
+    if recvpkt != None:
+            print "Received frame"
+            # If packet is an assocation response, get the assigned device
+            # short address, else get None if packet isn't the right type
+            value = associate_response_handle(recvpkt['bytes'])
+            if value != None:
+                print "Short address: {0}".format(repr(value))
+                kb.sniffer_off()
+                kb.inject('\x02\x00'+getAckByte(recvpkt['bytes']))
+                break
+
 
 if value == None:
     print "Sorry, we didn't hear a device respond with an association response. Do you have an active target within range?"

--- a/tools/zbkey
+++ b/tools/zbkey
@@ -58,9 +58,9 @@ def associate_response_handle(packet):
     print "Length of packet received in associate_handle: {0}".format(len(packet))
     try:
         if packet[33] == '\x02':
-            print("test2")
-            short_addr = packet[34:36]
-            return short_addr
+            if packet[34:36] != "\x00\x8d":
+                short_addr = packet[34:36]
+                return short_addr
         else:
             return None 
     except:
@@ -107,16 +107,16 @@ arg_delay = 4
 # Parameters to build association packet
 arg_IEE64addr = None    #May be specified on command line
 arg_panID = None        #May be specified on command line
-ASSOC_SEQNUM = '\x01'
+ASSOC_SEQNUM = '\x70'
 ASSOC_DST = '\x00\x00'
 ASSOC_SRC_PANID = '\xff\xff'
 assoc_packet = None
 
 # Parameters to build data packet
-ASSOC_DATA_SEQNUM = '\x02'
+ASSOC_DATA_SEQNUM = '\x71'
 
 # key transport data arguments
-DATA_KEY_SEQNUM = '\x03'
+DATA_KEY_SEQNUM = '\x72'
 
 # Command Line Processing
 while len(sys.argv) > 1:
@@ -207,7 +207,7 @@ if value == None:
 # Now build a packet to issue the SECOND DATA REQUEST, for the key to be sent
 if value != None:
     data_key_packet = '\x63\x88'+DATA_KEY_SEQNUM+arg_panID+ASSOC_DST+value+'\x04' # data packet after association response 
-    print "Sending the data key packet..."
+    print "Sending the data key packet with short address..."
     #print kbutils.hexdump(data_key_packet)
     kb.inject(data_key_packet)
 

--- a/tools/zbreplay
+++ b/tools/zbreplay
@@ -46,6 +46,7 @@ parser.add_argument('-R', '--dsnafile', action='store', default=None)
 parser.add_argument('-c', '-f', '--channel', action='store', type=int, default=None)
 parser.add_argument('-n', '--count', action='store', type=int, default=-1)
 parser.add_argument('-s', '--sleep', action='store', type=float, default=1.0)
+parser.add_argument('-z', '--subghz_page', action='store', type=int, default=0)
 parser.add_argument('-D', action='store_true', dest='showdev')
 args = parser.parse_args()
 
@@ -69,7 +70,7 @@ elif args.dsnafile is not None:
 
 kb = KillerBee(device=args.devstring)
 signal.signal(signal.SIGINT, interrupt)
-if not kb.is_valid_channel(args.channel):
+if not kb.is_valid_channel(args.channel, args.subghz_page):
     print >>sys.stderr, "ERROR: Must specify a valid IEEE 802.15.4 channel for the selected device."
     kb.close()
     sys.exit(1)


### PR DESCRIPTION
is_valid_channel() function needs 3 arguments: self, channel and page. 
Zbreplay and zbjammer give 2 arguments, self and channel. 
Error occurs: is_valid_channel() takes exactly 3 arguments (2 given).