### PR TITLE
Allow config changes after import

### DIFF
--- a/killerbee/__init__.py
+++ b/killerbee/__init__.py
@@ -9,7 +9,10 @@ from pcapdlt import *
 from kbutils import *      #provides serial, usb, USBVER
 from zigbeedecode import * #would like to import only within killerbee class
 from dot154decode import * #would like to import only within killerbee class
-from config import *       #to get DEV_ENABLE_* variables
+# for backwards compatibility
+from config import (DEV_ENABLE_SL_NODETEST, DEV_ENABLE_SL_BEEHIVE, DEV_ENABLE_FREAKDUINO, DEV_ENABLE_ZIGDUINO, DB_HOST,
+                    DB_NAME, DB_PASS, DB_PORT, DB_USER)
+import config  # to get DEV_ENABLE_* variables
 
 # Utility Functions
 def getKillerBee(channel, page= 0):
@@ -141,16 +144,16 @@ class KillerBee:
                 self.dev = device
                 if (self.dev == gps_devstring):
                     pass
-                elif (DEV_ENABLE_SL_NODETEST and kbutils.issl_nodetest(self.dev)):
+                elif ((config.DEV_ENABLE_SL_NODETEST or DEV_ENABLE_SL_NODETEST) and kbutils.issl_nodetest(self.dev)):
                     from dev_sl_nodetest import SL_NODETEST
                     self.driver = SL_NODETEST(self.dev)
-                elif (DEV_ENABLE_SL_BEEHIVE and kbutils.issl_beehive(self.dev)):
+                elif ((config.DEV_ENABLE_SL_BEEHIVE or DEV_ENABLE_SL_BEEHIVE) and kbutils.issl_beehive(self.dev)):
                     from dev_sl_beehive import SL_BEEHIVE
                     self.driver = SL_BEEHIVE(self.dev)
-                elif (DEV_ENABLE_ZIGDUINO and kbutils.iszigduino(self.dev)):
+                elif ((config.DEV_ENABLE_ZIGDUINO or DEV_ENABLE_ZIGDUINO) and kbutils.iszigduino(self.dev)):
                     from dev_zigduino import ZIGDUINO
                     self.driver = ZIGDUINO(self.dev)
-                elif (DEV_ENABLE_FREAKDUINO and kbutils.isfreakduino(self.dev)):
+                elif ((config.DEV_ENABLE_FREAKDUINO or DEV_ENABLE_FREAKDUINO) and kbutils.isfreakduino(self.dev)):
                     from dev_freakduino import FREAKDUINO
                     self.driver = FREAKDUINO(self.dev)
                 else:

--- a/killerbee/dblog.py
+++ b/killerbee/dblog.py
@@ -1,4 +1,4 @@
-from config import *
+import config
 import MySQLdb
 
 class DBReader:
@@ -6,7 +6,8 @@ class DBReader:
         self.conn = None
         self.db = None
         # Initalize the connection
-        self.db = MySQLdb.connect(user=DB_USER, passwd=DB_PASS, db=DB_NAME, host=DB_HOST, port=DB_PORT)
+        self.db = MySQLdb.connect(user=config.DB_USER, passwd=config.DB_PASS, db=config.DB_NAME, host=config.DB_HOST,
+                                  port=config.DB_PORT)
         if self.db == None:
             raise Exception("DBLogger: Unable to connect to database.")
         self.conn = self.db.cursor()

--- a/killerbee/kbutils.py
+++ b/killerbee/kbutils.py
@@ -21,7 +21,7 @@ import random
 import inspect
 from struct import pack
 
-from config import *       #to get DEV_ENABLE_* variables
+import config
 
 # Known devices by USB ID:
 RZ_USB_VEND_ID      = 0x03EB
@@ -288,13 +288,13 @@ def devlist(vendor=None, product=None, gps=None, include=None):
         if serialdev == gps_devstring:
             print("kbutils.devlist is skipping ignored/GPS device string {0}".format(serialdev)) #TODO remove debugging print
             continue
-        elif (DEV_ENABLE_SL_NODETEST and issl_nodetest(serialdev)):
+        elif (config.DEV_ENABLE_SL_NODETEST and issl_nodetest(serialdev)):
             devlist.append([serialdev, "Silabs NodeTest", ""])
-        elif (DEV_ENABLE_SL_BEEHIVE and issl_beehive(serialdev)):
+        elif (config.DEV_ENABLE_SL_BEEHIVE and issl_beehive(serialdev)):
             devlist.append([serialdev, "BeeHive SG", ""])
-        elif (DEV_ENABLE_ZIGDUINO and iszigduino(serialdev)):
+        elif (config.DEV_ENABLE_ZIGDUINO and iszigduino(serialdev)):
             devlist.append([serialdev, "Zigduino", ""])
-        elif (DEV_ENABLE_FREAKDUINO and isfreakduino(serialdev)):
+        elif (config.DEV_ENABLE_FREAKDUINO and isfreakduino(serialdev)):
             #TODO maybe move support for freakduino into goodfetccspi subtype==?
             devlist.append([serialdev, "Dartmouth Freakduino", ""])
         else:
@@ -360,7 +360,7 @@ def isgoodfetccspi(serialdev):
     from GoodFETCCSPI import GoodFETCCSPI
     os.environ["platform"] = ""
     # First try tmote detection
-    if DEV_ENABLE_TELOSB:
+    if config.DEV_ENABLE_TELOSB:
         os.environ["board"] = "telosb" #set enviroment variable for GoodFET code to use
         gf = GoodFETCCSPI()
         try:
@@ -375,7 +375,7 @@ def isgoodfetccspi(serialdev):
             if (gf.app == gf.CCSPIAPP) and (gf.verb == 0):
                 return True, 0
     # Try apimote v2 detection
-    if DEV_ENABLE_APIMOTE2:
+    if config.DEV_ENABLE_APIMOTE2:
         os.environ["board"] = "apimote2" #set enviroment variable for GoodFET code to use
         gf = GoodFETCCSPI()
         try:
@@ -391,7 +391,7 @@ def isgoodfetccspi(serialdev):
             if (gf.app == gf.CCSPIAPP) and (gf.verb == 0):
                 return True, 2
     # Then try apimote v1 detection
-    if DEV_ENABLE_APIMOTE1:
+    if config.DEV_ENABLE_APIMOTE1:
         os.environ["board"] = "apimote1" #set enviroment variable for GoodFET code to use
         gf = GoodFETCCSPI()
         try:


### PR DESCRIPTION
With the `from config import *` syntax, the changes to the config must be made
before `kbutils.py` or `__init__.py` is imported. Otherwise the changes will be ignored.

With the `import config` syntax, the changes will also be visible if they occur
after the import.