### PR TITLE
Python3-Support Part1

### DIFF
--- a/killerbee/GoodFET.py
+++ b/killerbee/GoodFET.py
@@ -5,23 +5,11 @@
 #
 # This code is being rewritten and refactored.  You've been warned!
 
-import sys, time, string, cStringIO, struct, glob, os;
+import sys, time, string, io, struct, glob, os;
 import sqlite3;
 
 fmt = ("B", "<H", None, "<L")
 
-def getClient(name="GoodFET"):
-    import GoodFET, GoodFETCC, GoodFETAVR, GoodFETSPI, GoodFETMSP430, GoodFETNRF, GoodFETCCSPI;
-    if(name=="GoodFET" or name=="monitor"): return GoodFET.GoodFET();
-    elif name=="cc" or name=="cc51": return GoodFETCC.GoodFETCC();
-    elif name=="cc2420" or name=="ccspi": return GoodFETCCSPI.GoodFETCCSPI();
-    elif name=="avr": return GoodFETAVR.GoodFETAVR();
-    elif name=="spi": return GoodFETSPI.GoodFETSPI();
-    elif name=="msp430": return GoodFETMSP430.GoodFETMSP430();
-    elif name=="nrf": return GoodFETNRF.GoodFETNRF();
-    
-    print "Unsupported target: %s" % name;
-    sys.exit(0);
 
 class SymbolTable:
     """GoodFET Symbol Table"""
@@ -53,25 +41,25 @@ class GoodFETbtser:
     def __init__(self,btaddr):
         import bluetooth;
         if btaddr==None or btaddr=="none" or btaddr=="bluetooth":
-            print "performing inquiry..."
+            print("performing inquiry...")
             nearby_devices = bluetooth.discover_devices(lookup_names = True)
-            print "found %d devices" % len(nearby_devices)
+            print("found %d devices" % len(nearby_devices))
             for addr, name in nearby_devices:
-                print "  %s - '%s'" % (addr, name)
+                print("  %s - '%s'" % (addr, name))
                 #TODO switch to wildcards.
                 if name=='FireFly-A6BD':
                     btaddr=addr;
                 if name=='RN42-A94A':
                     btaddr=addr;
                 
-            print "Please set $GOODFET to the address of your device.";
+            print("Please set $GOODFET to the address of your device.");
             sys.exit();
-        print "Identified GoodFET at %s" % btaddr;
+        print("Identified GoodFET at %s" % btaddr);
 
         # Manually use the portnumber.
         port=1;
         
-        print "Connecting to %s on port %i." % (btaddr, port);
+        print("Connecting to %s on port %i." % (btaddr, port));
         sock=bluetooth.BluetoothSocket(bluetooth.RFCOMM);
         self.sock=sock;
         sock.connect((btaddr,port));
@@ -121,7 +109,7 @@ class GoodFET:
     def name2adr(self,name):
         return self.symbols.get(name);
     def timeout(self):
-        print "timeout\n";
+        print("timeout\n");
     def serInit(self, port=None, timeout=2, attemptlimit=None):
         """Open a serial port of some kind."""
         import re;
@@ -144,7 +132,7 @@ class GoodFET:
         fixserial=False;
         
         if os.name=='nt' and sys.version.find('64 bit')!=-1:
-            print "WARNING: PySerial requires a 32-bit Python build in Windows.";
+            print("WARNING: PySerial requires a 32-bit Python build in Windows.");
         
         if port is None and os.environ.get("GOODFET")!=None:
             glob_list = glob.glob(os.environ.get("GOODFET"));
@@ -197,10 +185,10 @@ class GoodFET:
                 if attemptlimit is not None and attempts >= attemptlimit:
                     return
                 elif attempts==2 and os.environ.get("board")!='telosb':
-                    print "See the GoodFET FAQ about missing info flash.";
+                    print("See the GoodFET FAQ about missing info flash.");
                     self.serialport.timeout = 0.2;
                 elif attempts == 100:
-		    print "Tried 100 times to connect and failed."
+		    print("Tried 100 times to connect and failed.")
 		    sys.stdout.write("Continuing to try forever.")	# No newline
 		    sys.stdout.flush()
 		    self.verbose=True	# Something isn't going right, give the user more info
@@ -250,17 +238,17 @@ class GoodFET:
             #print "We have a connection."
             connected=1;
 	    if attempts >= 100:
-		print ""	# Add a newline
+		print("")	# Add a newline
             olds=self.infostring();
             clocking=self.monitorclocking();
             for foo in range(1,30):
                 if not self.monitorecho():
                     if self.verbose:
-                        print "Comm error on %i try, resyncing out of %s." % (foo,
-                                                                              clocking);
+                        print("Comm error on %i try, resyncing out of %s." % (foo,
+                                                                              clocking));
                     connected=0;
                     break;
-        if self.verbose: print "Connected after %02i attempts." % attempts;
+        if self.verbose: print("Connected after %02i attempts." % attempts);
         self.mon_connected();
         self.serialport.timeout = 12;
     def serClose(self):
@@ -415,7 +403,7 @@ class GoodFET:
 
     def getbuffer(self,size=0x1c00):
         writecmd(0,0xC2,[size&0xFF,(size>>16)&0xFF]);
-        print "Got %02x%02x buffer size." % (self.data[1],self.data[0]);
+        print("Got %02x%02x buffer size." % (self.data[1],self.data[0]));
 
     def writecmd(self, app, verb, count=0, data=[]):
         """Write a command and some data to the GoodFET."""
@@ -432,7 +420,7 @@ class GoodFET:
         self.serialport.write(chr(count>>8));
 
         if self.verbose:
-            print "Tx: ( 0x%02x, 0x%02x, 0x%04x )" % ( app, verb, count )
+            print("Tx: ( 0x%02x, 0x%02x, 0x%04x )" % ( app, verb, count ))
         
         #print "count=%02x, len(data)=%04x" % (count,len(data));
         
@@ -470,17 +458,17 @@ class GoodFET:
                     );
 
                 if self.verbose:
-                    print "Rx: ( 0x%02x, 0x%02x, 0x%04x )" % ( self.app, self.verb, self.count )
+                    print("Rx: ( 0x%02x, 0x%02x, 0x%04x )" % ( self.app, self.verb, self.count ))
             
                 #Debugging string; print, but wait.
                 if self.app==0xFF:
                     if self.verb==0xFF:
-                        print "# DEBUG %s" % self.serialport.read(self.count)
+                        print("# DEBUG %s" % self.serialport.read(self.count))
                	    elif self.verb==0xFE:
-                        print "# DEBUG 0x%x" % struct.unpack(fmt[self.count-1], self.serialport.read(self.count))[0]
+                        print("# DEBUG 0x%x" % struct.unpack(fmt[self.count-1], self.serialport.read(self.count))[0])
                     elif self.verb==0xFD:
                         #Do nothing, just wait so there's no timeout.
-                        print "# NOP.";
+                        print("# NOP.");
                         
                     sys.stdout.flush();
                 else:
@@ -488,7 +476,7 @@ class GoodFET:
                     return self.data;
             except TypeError:
                 if self.connected:
-                    print "Warning: waiting for serial read timed out (most likely).";
+                    print("Warning: waiting for serial read timed out (most likely).");
                     #print "This shouldn't happen after syncing.  Exiting for safety.";                    
                     #sys.exit(-1)
                 return self.data;
@@ -515,10 +503,10 @@ class GoodFET:
         """Time the execution of a verb."""
         if data==None: data=[];
         self.data=[app&0xff, verb&0xFF]+data;
-        print "Timing app %02x verb %02x." % (app,verb);
+        print("Timing app %02x verb %02x." % (app,verb));
         self.writecmd(self.GLITCHAPP,0x82,len(self.data),self.data);
         time=ord(self.data[0])+(ord(self.data[1])<<8);
-        print "Timed to be %i." % time;
+        print("Timed to be %i." % time);
         return time;
     def glitchVoltages(self,low=0x0880, high=0x0fff):
         """Set glitching voltages. (0x0fff is max.)"""
@@ -537,7 +525,7 @@ class GoodFET:
     def silent(self,s=0):
         """Transmissions halted when 1."""
         self.besilent=s;
-        print "besilent is %i" % self.besilent;
+        print("besilent is %i" % self.besilent);
         self.writecmd(0,0xB0,1,[s]);
     connected=0;
     def mon_connected(self):
@@ -572,7 +560,7 @@ class GoodFET:
         return self.MONpeek8(address)+(self.MONpeek8(address+1)<<8);
     def eeprompeek(self,address):
         """Read a word of memory from the monitor."""
-        print "EEPROM peeking not supported for the monitor.";
+        print("EEPROM peeking not supported for the monitor.");
         #return self.MONpeek8(address)+(self.MONpeek8(address+1)<<8);
     def peekbysym(self,name):
         """Read a value by its symbol name."""
@@ -601,20 +589,20 @@ class GoodFET:
         """Set a secret word for later retreival.  Used by glitcher."""
         #self.eeprompoke(0,value);
         #self.eeprompoke(1,value);
-        print "Secret setting is not yet suppored for this target.";
-        print "Aborting.";
+        print("Secret setting is not yet suppored for this target.");
+        print("Aborting.");
         
     def getsecret(self):
         """Get a secret word.  Used by glitcher."""
         #self.eeprompeek(0);
-        print "Secret getting is not yet suppored for this target.";
-        print "Aborting.";
+        print("Secret getting is not yet suppored for this target.");
+        print("Aborting.");
         sys.exit();
     
     def dumpmem(self,begin,end):
         i=begin;
         while i<end:
-            print "%04x %04x" % (i, self.MONpeek16(i));
+            print("%04x %04x" % (i, self.MONpeek16(i)));
             i+=2;
     def monitor_ram_pattern(self):
         """Overwrite all of RAM with 0xBEEF."""
@@ -636,25 +624,25 @@ class GoodFET:
         """Change the baud rate.  TODO fix this."""
         rates=self.baudrates;
         self.data=[baud];
-        print "Changing FET baud."
+        print("Changing FET baud.")
         self.serialport.write(chr(0x00));
         self.serialport.write(chr(0x80));
         self.serialport.write(chr(1));
         self.serialport.write(chr(baud));
         
-        print "Changed host baud."
+        print("Changed host baud.")
         self.serialport.baudrate = rates[baud];
         time.sleep(1);
         self.serialport.flushInput()
         self.serialport.flushOutput()
         
-        print "Baud is now %i." % rates[baud];
+        print("Baud is now %i." % rates[baud]);
         return;
     def readbyte(self):
         return ord(self.serialport.read(1));
     def findbaud(self):
         for r in self.baudrates:
-            print "\nTrying %i" % r;
+            print("\nTrying %i" % r);
             self.serialport.baudrate = r;
             #time.sleep(1);
             self.serialport.flushInput()
@@ -663,25 +651,25 @@ class GoodFET:
             for i in range(1,10):
                 self.readbyte();
             
-            print "Read %02x %02x %02x %02x" % (
-                self.readbyte(),self.readbyte(),self.readbyte(),self.readbyte());
+            print("Read %02x %02x %02x %02x" % (
+                self.readbyte(),self.readbyte(),self.readbyte(),self.readbyte()));
 
     def monitortest(self):
         """Self-test several functions through the monitor."""
-        print "Performing monitor self-test.";
+        print("Performing monitor self-test.");
         self.monitorclocking();
         for f in range(0,3000):
             a=self.MONpeek16(0x0c00);
             b=self.MONpeek16(0x0c02);
             if a!=0x0c04 and a!=0x0c06:
-                print "ERROR Fetched %04x, %04x" % (a,b);
+                print("ERROR Fetched %04x, %04x" % (a,b));
             self.pokebyte(0x0021,0); #Drop LED
             if self.MONpeek8(0x0021)!=0:
-                print "ERROR, P1OUT not cleared.";
+                print("ERROR, P1OUT not cleared.");
             self.pokebyte(0x0021,1); #Light LED
             if not self.monitorecho():
-                print "Echo test failed.";
-        print "Self-test complete.";
+                print("Echo test failed.");
+        print("Self-test complete.");
         self.monitorclocking();
 
     def monitorecho(self):
@@ -689,22 +677,22 @@ class GoodFET:
         self.writecmd(self.MONITORAPP,0x81,len(data),data);
         if self.data!=data:
             if self.verbose:
-                print "Comm error recognized by monitorecho(), got:\n%s" % self.data;
+                print("Comm error recognized by monitorecho(), got:\n%s" % self.data);
             return 0;
         return 1;
 
     def monitor_info(self):
-        print "GoodFET with %s MCU" % self.infostring();
-        print "Clocked at %s" % self.monitorclocking();
+        print("GoodFET with %s MCU" % self.infostring());
+        print("Clocked at %s" % self.monitorclocking());
         return 1;
 
     def testleds(self):
-        print "Flashing LEDs"
+        print("Flashing LEDs")
         self.writecmd(self.MONITORAPP,0xD0,0,"")
         try:
-            print "Flashed %d LED." % ord(self.data)
+            print("Flashed %d LED." % ord(self.data))
         except:
-            print "Unable to process response:", self.data
+            print("Unable to process response:", self.data)
         return 1
 
     def monitor_list_apps(self, full=False): 
@@ -716,13 +704,13 @@ class GoodFET:
         
         # read the build date string 
         self.readcmd()
-        print "Build Date: %s" % self.data
-        print "Firmware apps:"
+        print("Build Date: %s" % self.data)
+        print("Firmware apps:")
         while True:
             self.readcmd()
             if self.count == 0:
                 break
-            print self.data
+            print(self.data)
         return 1;
 
     def monitorclocking(self):
@@ -750,34 +738,34 @@ class GoodFET:
             b=self.MONpeek8(0xff1);
             return "%02x%02x" % (a,b);
     def lock(self):
-        print "Locking Unsupported.";
+        print("Locking Unsupported.");
     def erase(self):
-        print "Erasure Unsupported.";
+        print("Erasure Unsupported.");
     def setup(self):
         return;
     def start(self):
         return;
     def test(self):
-        print "Unimplemented.";
+        print("Unimplemented.");
         return;
     def status(self):
-        print "Unimplemented.";
+        print("Unimplemented.");
         return;
     def halt(self):
-        print "Unimplemented.";
+        print("Unimplemented.");
         return;
     def resume(self):
-        print "Unimplemented.";
+        print("Unimplemented.");
         return;
     def getpc(self):
-        print "Unimplemented.";
+        print("Unimplemented.");
         return 0xdead;
     def flash(self,file):
         """Flash an intel hex file to code memory."""
-        print "Flash not implemented.";
+        print("Flash not implemented.");
     def dump(self,file,start=0,stop=0xffff):
         """Dump an intel hex file from code memory."""
-        print "Dump not implemented.";
+        print("Dump not implemented.");
     def peek32(self,address, memory="vn"):
         """Peek 32 bits."""
         return (self.peek16(address,memory)+
@@ -791,7 +779,7 @@ class GoodFET:
         return self.MONpeek8(address); #monitor
     def peekblock(self,address,length,memory="vn"):
         """Return a block of data."""
-        data=range(0,length);
+        data=list(range(0,length));
         for foo in range(0,length):
             data[foo]=self.peek8(address+foo,memory);
         return data;

--- a/killerbee/GoodFET.py
+++ b/killerbee/GoodFET.py
@@ -188,13 +188,13 @@ class GoodFET:
                     print("See the GoodFET FAQ about missing info flash.");
                     self.serialport.timeout = 0.2;
                 elif attempts == 100:
-		    print("Tried 100 times to connect and failed.")
-		    sys.stdout.write("Continuing to try forever.")	# No newline
-		    sys.stdout.flush()
-		    self.verbose=True	# Something isn't going right, give the user more info
+                    print("Tried 100 times to connect and failed.")
+                    sys.stdout.write("Continuing to try forever.")  # No newline
+                    sys.stdout.flush()
+                    self.verbose=True   # Something isn't going right, give the user more info
                 elif attempts > 100 and attempts % 10 == 0:
-		    sys.stdout.write('.')
-		    sys.stdout.flush()
+                    sys.stdout.write('.')
+                    sys.stdout.flush()
                 #self.serialport.flushInput()
                 #self.serialport.flushOutput()
                 
@@ -237,8 +237,8 @@ class GoodFET:
             #Here we have a connection, but maybe not a good one.
             #print "We have a connection."
             connected=1;
-	    if attempts >= 100:
-		print("")	# Add a newline
+        if attempts >= 100:
+            print("")   # Add a newline
             olds=self.infostring();
             clocking=self.monitorclocking();
             for foo in range(1,30):

--- a/killerbee/GoodFET.py
+++ b/killerbee/GoodFET.py
@@ -5,7 +5,7 @@
 #
 # This code is being rewritten and refactored.  You've been warned!
 
-import sys, time, string, io, struct, glob, os;
+import sys, time, struct, glob, os;
 import sqlite3;
 
 fmt = ("B", "<H", None, "<L")

--- a/killerbee/GoodFETAVR.py
+++ b/killerbee/GoodFETAVR.py
@@ -5,8 +5,6 @@
 #
 # This code is being rewritten and refactored.  You've been warned!
 
-import sys, time, string, io, struct, glob, os;
-
 from .GoodFET import GoodFET;
 
 class GoodFETAVR(GoodFET):

--- a/killerbee/GoodFETAVR.py
+++ b/killerbee/GoodFETAVR.py
@@ -5,9 +5,9 @@
 #
 # This code is being rewritten and refactored.  You've been warned!
 
-import sys, time, string, cStringIO, struct, glob, os;
+import sys, time, string, io, struct, glob, os;
 
-from GoodFET import GoodFET;
+from .GoodFET import GoodFET;
 
 class GoodFETAVR(GoodFET):
     AVRAPP=0x32;
@@ -107,7 +107,7 @@ class GoodFETAVR(GoodFET):
             #self.glitchVoltages(0x880, i);
             self.start();
             bits=self.lockbits();
-            print "At %04x, Lockbits: %02x" % (i,bits);
+            print("At %04x, Lockbits: %02x" % (i,bits));
             if(bits==0xFF): return;
     def erase(self):
         """Erase the target chip."""

--- a/killerbee/GoodFETCCSPI.py
+++ b/killerbee/GoodFETCCSPI.py
@@ -5,9 +5,9 @@
 #
 # This code is being rewritten and refactored.  You've been warned!
 
-import sys, time, string, cStringIO, struct, glob, os;
+import sys, time, string, io, struct, glob, os;
 
-from GoodFET import GoodFET;
+from .GoodFET import GoodFET;
 
 class GoodFETCCSPI(GoodFET):
     CCSPIAPP=0x51;
@@ -79,8 +79,8 @@ class GoodFETCCSPI(GoodFET):
         try:
             toret=( ord(self.data[2]) + (ord(self.data[1])<<8) );
         except Exception as e:
-            print "issue in peeking for a register"
-            print e
+            print("issue in peeking for a register")
+            print(e)
             toret=( (ord(self.data[1])<<8) );
         return toret;
     def poke(self,reg,val,bytes=2):
@@ -88,10 +88,10 @@ class GoodFETCCSPI(GoodFET):
         data=[reg,(val>>8)&0xFF,val&0xFF];
         self.writecmd(self.CCSPIAPP,0x03,len(data),data);
         if self.peek(reg,bytes)!=val and reg!=0x18:
-            print "Warning, failed to set r%02x=0x%04x, got %02x." %(
+            print("Warning, failed to set r%02x=0x%04x, got %02x." %(
                 reg,
                 val,
-                self.peek(reg,bytes));
+                self.peek(reg,bytes)));
             return False;
         return True;
     
@@ -135,12 +135,12 @@ class GoodFETCCSPI(GoodFET):
     
     def RF_setkey(self,key):
         """Sets the first key for encryption to the given argument."""
-        print "ERROR: Forgot to set the key.";
+        print("ERROR: Forgot to set the key.");
         
         return;
     def RF_setnonce(self,key):
         """Sets the first key for encryption to the given argument."""
-        print "ERROR: Forgot to set the nonce.";
+        print("ERROR: Forgot to set the nonce.");
         
         return;
     
@@ -163,7 +163,7 @@ class GoodFETCCSPI(GoodFET):
     def RF_setchan(self,channel):
         """Set the ZigBee/802.15.4 channel number."""
         if channel < 11 or channel > 26:
-            print "Only 802.15.4 channels 11 to 26 are currently supported.";
+            print("Only 802.15.4 channels 11 to 26 are currently supported.");
         else:
             self.RF_setfreq( ( (channel-11)*5 + 2405 ) * 1000000 );
     def RF_getsmac(self):
@@ -197,7 +197,7 @@ class GoodFETCCSPI(GoodFET):
         self.writecmd(self.CCSPIAPP,0x85,len(data),data);
         return;
     
-    lastpacket=range(0,0xff);
+    lastpacket=list(range(0,0xff));
     def RF_rxpacket(self):
         """Get a packet from the radio.  Returns None if none is
         waiting."""
@@ -253,7 +253,7 @@ class GoodFETCCSPI(GoodFET):
            and that also sends a forged ACK if needed."""
         data = "";
         self.writecmd(self.CCSPIAPP,0xA1,len(data),data);
-        print "Got:", data, "and", self.data
+        print("Got:", data, "and", self.data)
         return;
 
     def RF_modulated_spectrum(self):
@@ -366,7 +366,7 @@ class GoodFETCCSPI(GoodFET):
         self.poke(0x03,choice);
         self.maclen=len;
     def printpacket(self,packet,prefix="#"):
-        print self.packet2str(packet,prefix);
+        print(self.packet2str(packet,prefix));
     def packet2str(self,packet,prefix="#"):
         s="";
         i=0;
@@ -378,9 +378,9 @@ class GoodFETCCSPI(GoodFET):
         try:
             from scapy.all import Dot15d4
         except ImportError:
-            print "To use packet disection, Scapy must be installed and have the Dot15d4 extension present."
-            print "try: hg clone http://hg.secdev.org/scapy-com";
-            print "     sudo ./setup.py install";
+            print("To use packet disection, Scapy must be installed and have the Dot15d4 extension present.")
+            print("try: hg clone http://hg.secdev.org/scapy-com");
+            print("     sudo ./setup.py install");
         self.printpacket(packet);
         try:
             scapyd = Dot15d4(packet[1:]);

--- a/killerbee/GoodFETCCSPI.py
+++ b/killerbee/GoodFETCCSPI.py
@@ -5,7 +5,7 @@
 #
 # This code is being rewritten and refactored.  You've been warned!
 
-import sys, time, string, io, struct, glob, os;
+import time
 
 from .GoodFET import GoodFET;
 

--- a/killerbee/GoodFETatmel128.py
+++ b/killerbee/GoodFETatmel128.py
@@ -1,7 +1,7 @@
 # GoodFETclient to interface zigduino/atmel128 radio
 # forked by bx from code by neighbor Travis Goodspeed
 from .GoodFETAVR import GoodFETAVR
-import sys, binascii, os, array, time, glob, struct
+import sys, os, time, glob, struct
 
 fmt = ("B", "<H", None, "<L")
 

--- a/killerbee/GoodFETatmel128.py
+++ b/killerbee/GoodFETatmel128.py
@@ -1,6 +1,6 @@
 # GoodFETclient to interface zigduino/atmel128 radio
 # forked by bx from code by neighbor Travis Goodspeed
-from GoodFETAVR import GoodFETAVR
+from .GoodFETAVR import GoodFETAVR
 import sys, binascii, os, array, time, glob, struct
 
 fmt = ("B", "<H", None, "<L")
@@ -27,7 +27,7 @@ class GoodFETatmel128rfa1(GoodFETAVR):
             import serial;
 
             if os.name=='nt' and sys.version.find('64 bit')!=-1:
-                print "WARNING: PySerial requires a 32-bit Python build in Windows.";
+                print("WARNING: PySerial requires a 32-bit Python build in Windows.");
 
             if port is None and os.environ.get("GOODFET")!=None:
                 glob_list = glob.glob(os.environ.get("GOODFET"));
@@ -82,7 +82,7 @@ class GoodFETatmel128rfa1(GoodFETAVR):
                     attempts=attempts+1;
                     self.readcmd(); #Read the first command.
                     if self.verbose:
-                        print "Got %02x,%02x:'%s'" % (self.app,self.verb,self.data);
+                        print("Got %02x,%02x:'%s'" % (self.app,self.verb,self.data));
 
                 #Here we have a connection, but maybe not a good one.
                 #print "We have a connection."
@@ -91,12 +91,12 @@ class GoodFETatmel128rfa1(GoodFETAVR):
                     if not self.monitorecho():
                         self.connected = 0
                         if self.verbose:
-                            print "Comm error on try %i." % (foo)
+                            print("Comm error on try %i." % (foo))
                     else:
                         self.connected = 1
                         break
             if self.verbose:
-                print "Connected after %02i attempts." % attempts;
+                print("Connected after %02i attempts." % attempts);
             self.serialport.timeout = 12;
 
     def serClose(self):
@@ -109,7 +109,7 @@ class GoodFETatmel128rfa1(GoodFETAVR):
         self.serialport.write(chr(app));
         self.serialport.write(chr(verb));
         if self.verbose:
-            print "Tx: ( 0x%02x, 0x%02x, %d )" % ( app, verb, count )
+            print("Tx: ( 0x%02x, 0x%02x, %d )" % ( app, verb, count ))
         if count > 0:
             if(isinstance(data,list)):
                 old = data
@@ -124,14 +124,14 @@ class GoodFETatmel128rfa1(GoodFETAVR):
         self.serialport.write(chr(count>>8));
         if count > 0:
             if self.verbose:
-                print "sending: %s" %outstr.encode("hex")
+                print("sending: %s" %outstr.encode("hex"))
             self.serialport.write(outstr);
 
 
         if not self.besilent:
             out = self.readcmd()
             if out and self.verbose:
-                print "read: " + out.encode("hex")
+                print("read: " + out.encode("hex"))
             return out
         else:
             return None
@@ -143,7 +143,7 @@ class GoodFETatmel128rfa1(GoodFETAVR):
 
         if len(app) < 1:
             if self.verbose:
-                print "Rx: None"
+                print("Rx: None")
 
             self.app = 0
             self.verb = 0
@@ -166,17 +166,17 @@ class GoodFETatmel128rfa1(GoodFETAVR):
         else:
             self.count = 0
         if self.verbose:
-            print "Rx: ( 0x%02x, 0x%02x, %i )" % ( self.app, self.verb, self.count )
+            print("Rx: ( 0x%02x, 0x%02x, %i )" % ( self.app, self.verb, self.count ))
 
         #Debugging string; print, but wait.
         if self.app==0xFF:
             if self.verb==0xFF:
-                print "# DEBUG %s" % self.serialport.read(self.count)
+                print("# DEBUG %s" % self.serialport.read(self.count))
             elif self.verb==0xFE:
-                print "# DEBUG 0x%x" % struct.unpack(fmt[self.count-1], self.serialport.read(self.count))[0]
+                print("# DEBUG 0x%x" % struct.unpack(fmt[self.count-1], self.serialport.read(self.count))[0])
             elif self.verb==0xFD:
                         #Do nothing, just wait so there's no timeout.
-                print "# NOP.";
+                print("# NOP.");
             return ""
         else:
             self.data=self.serialport.read(self.count);
@@ -184,7 +184,7 @@ class GoodFETatmel128rfa1(GoodFETAVR):
 
     def RF_setchannel(self, chan):
         if (chan < 11) or (chan > 26):
-            print "Channel out of range"
+            print("Channel out of range")
         else:
             self.poke(0x8, chan)
 
@@ -192,7 +192,7 @@ class GoodFETatmel128rfa1(GoodFETAVR):
         """Read a Register. """
         #Automatically calibrate the len.
         if bytes != 1:
-            print "Warning, currently cannot poke more than 1 byte"
+            print("Warning, currently cannot poke more than 1 byte")
             bytes = 1
         data = [reg, 0, bytes%255, bytes>>8] #+ ([0]*bytes)
         self.data = None
@@ -213,7 +213,7 @@ class GoodFETatmel128rfa1(GoodFETAVR):
         data = [reg, 0] #+ ([0]*bytes)
         data=[reg, 0]
         if bytes != 1:
-            print "Warning, currently cannot poke more than 1 byte"
+            print("Warning, currently cannot poke more than 1 byte")
             bytes = 1
         for i in range(0,bytes):
             data=data+[(val>>(8*i))&0xFF];
@@ -221,10 +221,10 @@ class GoodFETatmel128rfa1(GoodFETAVR):
         self.writecmd(self.ATMELRADIOAPP,0x03,len(data),data);
         newval = self.peek(reg,bytes)
         if newval!=val:
-            print "Warning, failed to set r%02x=%02x, got %02x." %(
+            print("Warning, failed to set r%02x=%02x, got %02x." %(
                 reg,
                 val,
-                newval);
+                newval));
 
         return;
 

--- a/killerbee/__init__.py
+++ b/killerbee/__init__.py
@@ -2,17 +2,19 @@ import struct
 import glob
 from warnings import warn
 
-from pcapdump import *
-from daintree import *
-from pcapdlt import *
+from .pcapdump import *
+from .daintree import *
+from .pcapdlt import *
 
-from kbutils import *      #provides serial, usb, USBVER
-from zigbeedecode import * #would like to import only within killerbee class
-from dot154decode import * #would like to import only within killerbee class
+from .kbutils import *      #provides serial, usb, USBVER
+from .zigbeedecode import * #would like to import only within killerbee class
+from .dot154decode import * #would like to import only within killerbee class
 # for backwards compatibility
-from config import (DEV_ENABLE_SL_NODETEST, DEV_ENABLE_SL_BEEHIVE, DEV_ENABLE_FREAKDUINO, DEV_ENABLE_ZIGDUINO, DB_HOST,
+from .config import (DEV_ENABLE_SL_NODETEST, DEV_ENABLE_SL_BEEHIVE, DEV_ENABLE_FREAKDUINO, DEV_ENABLE_ZIGDUINO, DB_HOST,
                     DB_NAME, DB_PASS, DB_PORT, DB_USER)
-import config  # to get DEV_ENABLE_* variables
+import killerbee.config  # to get DEV_ENABLE_* variables
+
+config = killerbee.config
 
 # Utility Functions
 def getKillerBee(channel, page= 0):
@@ -45,9 +47,9 @@ def show_dev(vendor=None, product=None, gps=None, include=None):
         these to be enumerated. Aka, include only these items.
     '''
     fmt = "{: >14} {: <20} {: >10}"
-    print(fmt.format("Dev", "Product String", "Serial Number"))
+    print((fmt.format("Dev", "Product String", "Serial Number")))
     for dev in kbutils.devlist(vendor=vendor, product=product, gps=gps, include=include):
-        print(fmt.format(dev[0], dev[1], dev[2]))
+        print((fmt.format(dev[0], dev[1], dev[2])))
 
 # KillerBee Class
 class KillerBee:
@@ -81,9 +83,9 @@ class KillerBee:
         # discovery, just connecting to defined addresses, so we'll check
         # first to see if we have an IP address given as our device parameter.
         if (device is not None) and kbutils.isIpAddr(device):
-            from dev_sewio import isSewio
+            from .dev_sewio import isSewio
             if isSewio(device):
-                from dev_sewio import SEWIO
+                from .dev_sewio import SEWIO
                 self.driver = SEWIO(dev=device)  # give it the ip address
             else: del isSewio
 
@@ -111,15 +113,15 @@ class KillerBee:
 
             if self.dev is not None:
                 if self.__device_is(RZ_USB_VEND_ID, RZ_USB_PROD_ID):
-                    from dev_rzusbstick import RZUSBSTICK
+                    from .dev_rzusbstick import RZUSBSTICK
                     self.driver = RZUSBSTICK(self.dev, self.__bus)
                 elif self.__device_is(ZN_USB_VEND_ID, ZN_USB_PROD_ID):
                     raise KBInterfaceError("Zena firmware not yet implemented.")
                 elif self.__device_is(CC2530_USB_VEND_ID, CC2530_USB_PROD_ID):
-                    from dev_cc253x import CC253x
+                    from .dev_cc253x import CC253x
                     self.driver = CC253x(self.dev, self.__bus, CC253x.VARIANT_CC2530)
                 elif self.__device_is(CC2531_USB_VEND_ID, CC2531_USB_PROD_ID):
-                    from dev_cc253x import CC253x
+                    from .dev_cc253x import CC253x
                     self.driver = CC253x(self.dev, self.__bus, CC253x.VARIANT_CC2531)
                 else:
                     raise KBInterfaceError("KillerBee doesn't know how to interact with USB device vendor=%04x, product=%04x." % (self.dev.idVendor, self.dev.idProduct))
@@ -145,27 +147,27 @@ class KillerBee:
                 if (self.dev == gps_devstring):
                     pass
                 elif ((config.DEV_ENABLE_SL_NODETEST or DEV_ENABLE_SL_NODETEST) and kbutils.issl_nodetest(self.dev)):
-                    from dev_sl_nodetest import SL_NODETEST
+                    from .dev_sl_nodetest import SL_NODETEST
                     self.driver = SL_NODETEST(self.dev)
                 elif ((config.DEV_ENABLE_SL_BEEHIVE or DEV_ENABLE_SL_BEEHIVE) and kbutils.issl_beehive(self.dev)):
-                    from dev_sl_beehive import SL_BEEHIVE
+                    from .dev_sl_beehive import SL_BEEHIVE
                     self.driver = SL_BEEHIVE(self.dev)
                 elif ((config.DEV_ENABLE_ZIGDUINO or DEV_ENABLE_ZIGDUINO) and kbutils.iszigduino(self.dev)):
-                    from dev_zigduino import ZIGDUINO
+                    from .dev_zigduino import ZIGDUINO
                     self.driver = ZIGDUINO(self.dev)
                 elif ((config.DEV_ENABLE_FREAKDUINO or DEV_ENABLE_FREAKDUINO) and kbutils.isfreakduino(self.dev)):
-                    from dev_freakduino import FREAKDUINO
+                    from .dev_freakduino import FREAKDUINO
                     self.driver = FREAKDUINO(self.dev)
                 else:
                     gfccspi,subtype = isgoodfetccspi(self.dev)
                     if gfccspi and subtype == 0:
-                        from dev_telosb import TELOSB
+                        from .dev_telosb import TELOSB
                         self.driver = TELOSB(self.dev)
                     elif gfccspi and subtype == 1:
-                        from dev_apimote import APIMOTE
+                        from .dev_apimote import APIMOTE
                         self.driver = APIMOTE(self.dev, revision=1)
                     elif gfccspi and subtype == 2:
-                        from dev_apimote import APIMOTE
+                        from .dev_apimote import APIMOTE
                         self.driver = APIMOTE(self.dev, revision=2)
                     else:
                         raise KBInterfaceError("KillerBee doesn't know how to interact with serial device at '%s'." % self.dev)
@@ -176,7 +178,7 @@ class KillerBee:
         # Start a connection to the remote packet logging server, if able:
         if datasource is not None:
             try:
-                import dblog
+                from . import dblog
                 self.dblog = dblog.DBLogger(datasource)
             except Exception as e:
                 warn("Error initializing DBLogger (%s)." % e)

--- a/killerbee/__init__.py
+++ b/killerbee/__init__.py
@@ -12,9 +12,8 @@ from .dot154decode import * #would like to import only within killerbee class
 # for backwards compatibility
 from .config import (DEV_ENABLE_SL_NODETEST, DEV_ENABLE_SL_BEEHIVE, DEV_ENABLE_FREAKDUINO, DEV_ENABLE_ZIGDUINO, DB_HOST,
                     DB_NAME, DB_PASS, DB_PORT, DB_USER)
-import killerbee.config  # to get DEV_ENABLE_* variables
+import killerbee.config as config  # to get DEV_ENABLE_* variables
 
-config = killerbee.config
 
 # Utility Functions
 def getKillerBee(channel, page= 0):

--- a/killerbee/dblog.py
+++ b/killerbee/dblog.py
@@ -1,4 +1,4 @@
-import config
+import killerbee.config as config
 import MySQLdb
 
 class DBReader:
@@ -47,7 +47,8 @@ class DBLogger:
         # Initalize the connection
         try:
             self.db = MySQLdb.connect(user=DB_USER, passwd=DB_PASS, db=DB_NAME, host=DB_HOST, port=DB_PORT)
-        except Exception as (errno, errmsg):
+        except Exception as xxx_todo_changeme:
+            (errno, errmsg) = xxx_todo_changeme.args
             raise Exception("DBLogger was unable to connect to the database: " \
                             +"(error %d): %s (Note: connection values should be in config.py)." % (errno,errmsg))
         if self.db == None: #this backup check may be redundant
@@ -57,7 +58,7 @@ class DBLogger:
         # Set the ds_id attribute to correspond to the requested data source name
         self.conn.execute("SELECT ds_id FROM datasources WHERE ds_name LIKE %s LIMIT 1", (datasource,))
         if self.conn.rowcount == 1: self.ds_id = self.conn.fetchone()
-        else: print "No datasource found matching name:", datasource
+        else: print("No datasource found matching name:", datasource)
 
     def close(self):
         if self.conn != None:

--- a/killerbee/dblog.py
+++ b/killerbee/dblog.py
@@ -47,8 +47,8 @@ class DBLogger:
         # Initalize the connection
         try:
             self.db = MySQLdb.connect(user=DB_USER, passwd=DB_PASS, db=DB_NAME, host=DB_HOST, port=DB_PORT)
-        except Exception as xxx_todo_changeme:
-            (errno, errmsg) = xxx_todo_changeme.args
+        except Exception as exc:
+            (errno, errmsg) = exc.args
             raise Exception("DBLogger was unable to connect to the database: " \
                             +"(error %d): %s (Note: connection values should be in config.py)." % (errno,errmsg))
         if self.db == None: #this backup check may be redundant

--- a/killerbee/dev_apimote.py
+++ b/killerbee/dev_apimote.py
@@ -17,8 +17,8 @@ import time
 import struct
 import time
 from datetime import datetime, timedelta
-from kbutils import KBCapabilities, makeFCS
-from GoodFETCCSPI import GoodFETCCSPI
+from .kbutils import KBCapabilities, makeFCS
+from .GoodFETCCSPI import GoodFETCCSPI
 
 # Default revision of the ApiMote. This is liable to change at any time
 # as new ApiMote versions are released. Automatic recognition would be nice.

--- a/killerbee/dev_cc253x.py
+++ b/killerbee/dev_cc253x.py
@@ -2,12 +2,12 @@
 CC253x support is contributed by Scytmo.
 """
 
-from __future__ import print_function
+
 import sys
 import struct
 import time
 from datetime import datetime
-from kbutils import KBCapabilities, makeFCS
+from .kbutils import KBCapabilities, makeFCS
 
 # Import USB support depending on version of pyUSB
 try:

--- a/killerbee/dev_cc253x.py
+++ b/killerbee/dev_cc253x.py
@@ -3,6 +3,7 @@ CC253x support is contributed by Scytmo.
 """
 
 
+from __future__ import print_function
 import sys
 import struct
 import time

--- a/killerbee/dev_freakduino.py
+++ b/killerbee/dev_freakduino.py
@@ -10,7 +10,7 @@ import time
 import struct
 from datetime import datetime, date
 from datetime import time as dttime
-from kbutils import KBCapabilities, makeFCS
+from .kbutils import KBCapabilities, makeFCS
 
 MODE_NONE    = 0x01
 MODE_SNIFF   = 0x02
@@ -89,7 +89,7 @@ class FREAKDUINO:
         Ex: If provided cmdstr = "C!N" it will send "SC!N", telling the device to turn on sniffing ("N"),
         and it expects to receive a confirmation back "&C!N" to confirm success.
         '''
-        print "Flushing out of buffer:", self.handle.inWaiting()
+        print("Flushing out of buffer:", self.handle.inWaiting())
         self.handle.flushInput()
         if len(cmdstr) > 3:
             raise Exception("Command string is less than minimum length (S%s)." % cmdstr)
@@ -98,16 +98,16 @@ class FREAKDUINO:
         # TODO ugly and unreliable:
         # This should just wait for a & and then parse things after it,
         # however it seems sometimes you have to resend the command or something.
-        print "Line:", self.handle.readline(eol='&')
+        print("Line:", self.handle.readline(eol='&'))
         counter = 0
         char = self.handle.read()
         while (char != '&'):
-            print self.handle.inWaiting(), "Waiting...", char
+            print(self.handle.inWaiting(), "Waiting...", char)
             time.sleep(0.01)
             if (counter > 8):
                 self.__send_cmd(cmdstr, arg)
                 counter = 0
-                print "Resend Response Line:", self.handle.readline(eol='&')
+                print("Resend Response Line:", self.handle.readline(eol='&'))
             else: counter += 1
             char = self.handle.read()
         response = ''
@@ -115,10 +115,10 @@ class FREAKDUINO:
             response += self.handle.read()
 
         if response == cmdstr[:3]:
-            print "Got a response:", response, "matches", cmdstr
+            print("Got a response:", response, "matches", cmdstr)
             return True
         else:
-            print "Invalid response:", response, cmdstr[:3]
+            print("Invalid response:", response, cmdstr[:3])
             return False
 
     # Send the command for the Dartmouth-mod Freakduino to dump data logged in EEPROM
@@ -271,7 +271,7 @@ class FREAKDUINO:
             if frame[-2:] == makeFCS(frame[:-2]): validcrc = True
             else: validcrc = False
         except:
-            print "Error parsing stream received from device:", pdata, data
+            print("Error parsing stream received from device:", pdata, data)
             return None
         #Return in a nicer dictionary format, so we don't have to reference by number indicies.
         #Note that 0,1,2 indicies inserted twice for backwards compatibility.
@@ -286,7 +286,7 @@ class FREAKDUINO:
             timestr = "%08d" % (struct.unpack('L', data[1])[0]) #in format hhmmsscc
             time = dttime(int(timestr[:2]), int(timestr[2:4]), int(timestr[4:6]), int(timestr[6:]))
         except:
-            print "Issue with time format:", timestr, data
+            print("Issue with time format:", timestr, data)
             time = None
         if self.date == None: self.date = date.utcnow().date()
         if time == None or time == dttime.min: time = (datetime.utcnow()).time()
@@ -304,7 +304,7 @@ class FREAKDUINO:
         date = str(struct.unpack('L', ldata[12:16])[0])
         self.date = datetime.date(date[-2:], date[-4:-2], date[:-4])
         #TODO parse data formats (lon=-7228745 lat=4370648 alt=3800 age=63 date=70111 time=312530)
-        print self.lon, self.lat, self.alt, self.date
+        print(self.lon, self.lat, self.alt, self.date)
 
     def ping(self, da, panid, sa, channel=None, page=0):
         '''

--- a/killerbee/dev_rzusbstick.py
+++ b/killerbee/dev_rzusbstick.py
@@ -4,7 +4,7 @@ try:
     import usb.util
     USBVER=1
     import sys
-    print >>sys.stderr, "Warning: You are using pyUSB 1.x, support is in beta."
+    print("Warning: You are using pyUSB 1.x, support is in beta.", file=sys.stderr)
 except ImportError:
     import usb
     #print("Warning: You are using pyUSB 0.x, future deprecation planned.")
@@ -13,7 +13,7 @@ except ImportError:
 import time
 import struct
 from datetime import datetime
-from kbutils import KBCapabilities
+from .kbutils import KBCapabilities
 
 # Functions for RZUSBSTICK, not all are implemented in firmware
 # Functions not used are commented out but retained for prosperity
@@ -271,7 +271,7 @@ class RZUSBSTICK:
         if USBVER == 0: # TODO: UNTESTED!!!!
             try:
                 response = self.handle.bulkRead(RZ_USB_RESPONSE_EP, 1)[0]
-            except usb.USBError, e:
+            except usb.USBError as e:
                 if e.args != ('No error',): # http://bugs.debian.org/476796
                     raise e
         else: #pyUSB 1.x
@@ -283,10 +283,10 @@ class RZUSBSTICK:
                 #response = response.pop()
             except usb.core.USBError as e:
                 if e.errno != 110: #Not Operation timed out
-                    print "Error args:", e.args
+                    print("Error args:", e.args)
                     raise e
                 elif e.errno == 110:
-                    print "DEBUG: Received operation timed out error ...attempting to continue."
+                    print("DEBUG: Received operation timed out error ...attempting to continue.")
         return response
 
     def __usb_write(self, endpoint, data, expected_response=RZ_RESP_SUCCESS):
@@ -304,7 +304,7 @@ class RZUSBSTICK:
                 self.handle.bulkWrite(endpoint, data)
                 # Returns a tuple, first value is an int as the RZ_RESP_* code
 #                response = self.handle.bulkRead(RZ_USB_RESPONSE_EP, 1)[0]
-            except usb.USBError, e:
+            except usb.USBError as e:
                 if e.args != ('No error',): # http://bugs.debian.org/476796
                     raise e
 #            time.sleep(0.0005)
@@ -322,10 +322,10 @@ class RZUSBSTICK:
 #                response = response.pop()
             except usb.core.USBError as e:
                 if e.errno != 110: #Not Operation timed out
-                    print "Error args:", e.args
+                    print("Error args:", e.args)
                     raise e
                 elif e.errno == 110:
-                    print "DEBUG: Received operation timed out error ...attempting to continue."
+                    print("DEBUG: Received operation timed out error ...attempting to continue.")
         #time.sleep(0.0005)
         response = self.__usb_read()
         #print 'response 0: %x' % response[0]
@@ -526,7 +526,7 @@ class RZUSBSTICK:
         # Append two bytes to be replaced with FCS by firmware.
         packet += "\x00\x00"
 
-        for pnum in xrange(count):
+        for pnum in range(count):
             # Format for packet is opcode RZ_CMD_INJECT_FRAME, one-byte length, 
             # packet data
             self.__usb_write(RZ_USB_COMMAND_EP, struct.pack("BB", RZ_CMD_INJECT_FRAME, len(packet)) + packet)
@@ -558,7 +558,7 @@ class RZUSBSTICK:
                 except usb.USBError as e:
                     if e.args != ('No error',): # http://bugs.debian.org/476796
                         if e.args[0] != "Connection timed out": # USB timeout issue
-                            print("Error args: {}".format(e.args))
+                            print(("Error args: {}".format(e.args)))
                             raise e
                         else:
                             return None
@@ -567,7 +567,7 @@ class RZUSBSTICK:
                     pdata = self.dev.read(RZ_USB_PACKET_EP, self.dev.bMaxPacketSize0, timeout=timeout)
                 except usb.core.USBError as e:
                     if e.errno != 110: #Operation timed out
-                        print("Error args: {}".format(e.args))
+                        print(("Error args: {}".format(e.args)))
                         raise e
                         #TODO error handling enhancements for USB 1.0
                     else:

--- a/killerbee/dev_rzusbstick.py
+++ b/killerbee/dev_rzusbstick.py
@@ -1,4 +1,5 @@
 # Import USB support depending on version of pyUSB
+from __future__ import print_function
 try:
     import usb.core
     import usb.util

--- a/killerbee/dev_sewio.py
+++ b/killerbee/dev_sewio.py
@@ -13,13 +13,13 @@ import os
 import time
 import struct
 import time
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import re
 from socket import socket, AF_INET, SOCK_DGRAM, SOL_SOCKET, SO_REUSEADDR, timeout as error_timeout
 from struct import unpack
 
 from datetime import datetime, timedelta
-from kbutils import KBCapabilities, makeFCS, isIpAddr, KBInterfaceError
+from .kbutils import KBCapabilities, makeFCS, isIpAddr, KBInterfaceError
 
 DEFAULT_IP = "10.10.10.2"   #IP address of the sniffer
 DEFAULT_GW = "10.10.10.1"   #IP address of the default gateway
@@ -44,18 +44,18 @@ Similar code from Wireshark source:
 '''
 def ntp_to_system_time(secs, msecs):
     """convert a NTP time to system time"""
-    print "Secs:", secs, msecs
-    print "\tUTC:", datetime.utcfromtimestamp(secs - 2208988800)
+    print("Secs:", secs, msecs)
+    print("\tUTC:", datetime.utcfromtimestamp(secs - 2208988800))
     return datetime.utcfromtimestamp(secs - 2208988800)
 
 def getFirmwareVersion(ip):
     try:
-        html = urllib2.urlopen("http://{0}/".format(ip))
+        html = urllib.request.urlopen("http://{0}/".format(ip))
         fw = re.search(r'Firmware version ([0-9.]+)', html.read())
         if fw is not None:
             return fw.group(1)
     except Exception as e:
-        print("Unable to connect to IP {0} (error: {1}).".format(ip, e))
+        print(("Unable to connect to IP {0} (error: {1}).".format(ip, e)))
     return None
 
 def getMacAddr(ip):
@@ -63,7 +63,7 @@ def getMacAddr(ip):
     Returns a string for the MAC address of the sniffer.
     '''
     try:
-        html = urllib2.urlopen("http://{0}/".format(ip))
+        html = urllib.request.urlopen("http://{0}/".format(ip))
         # Yup, we're going to have to steal the status out of a JavaScript variable
         #var values = removeSSItag('<!--#pindex-->STOPPED,00:1a:b6:00:0a:a4,...
         res = re.search(r'<!--#pindex-->[A-Z]+,((?:[0-9a-f]{2}:){5}[0-9a-f]{2})', html.read())
@@ -71,7 +71,7 @@ def getMacAddr(ip):
             raise KBInterfaceError("Unable to parse the sniffer's MAC address.")
         return res.group(1)
     except Exception as e:
-        print("Unable to connect to IP {0} (error: {1}).".format(ip, e))
+        print(("Unable to connect to IP {0} (error: {1}).".format(ip, e)))
     return None
 
 def isSewio(dev):
@@ -104,7 +104,7 @@ class SEWIO:
 
         self.__revision_num = getFirmwareVersion(self.dev)
         if self.__revision_num not in TESTED_FW_VERS:
-            print("Warning: Firmware revision {0} reported by the sniffer is not currently supported. Errors may occur and dev_sewio.py may need updating.".format(self.__revision_num))
+            print(("Warning: Firmware revision {0} reported by the sniffer is not currently supported. Errors may occur and dev_sewio.py may need updating.".format(self.__revision_num)))
 
         self.handle = socket(AF_INET, SOCK_DGRAM)
         self.handle.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
@@ -153,7 +153,7 @@ class SEWIO:
             returns True if an HTTP 200 code was received.
         '''
         try:
-            html = urllib2.urlopen("http://{0}/{1}".format(self.dev, path))
+            html = urllib.request.urlopen("http://{0}/{1}".format(self.dev, path))
             if fetch:
                 return html.read()
             else:
@@ -280,7 +280,7 @@ class SEWIO:
             curChannel = self.__sniffer_channel()
             if channel != curChannel:
                 self.modulation = self.__get_default_modulation(channel)
-                print("Setting to channel {0}, modulation {1}.".format(channel, self.modulation))
+                print(("Setting to channel {0}, modulation {1}.".format(channel, self.modulation)))
                 # Examples captured in fw v0.5 sniffing:
                 #   channel 6, 250 compliant: http://10.10.10.2/settings.cgi?chn=6&modul=c&rxsens=0
                 #   channel 12, 250 compliant: http://10.10.10.2/settings.cgi?chn=12&modul=0&rxsens=0
@@ -394,10 +394,10 @@ class SEWIO:
                 continue
             # Dissect the UDP packet
             (frame, ch, validcrc, rssi, lqival, recdtime) = self.__parse_zep_v2(data)
-            print "Valid CRC", validcrc, "LQI", lqival, "RSSI", rssi
+            print("Valid CRC", validcrc, "LQI", lqival, "RSSI", rssi)
             if frame == None or (ch is not None and ch != self._channel):
                 #TODO this maybe should be an error condition, instead of ignored?
-                print("ZEP parsing issue (bytes length={0}, channel={1}).".format(len(frame) if frame is not None else None, ch))
+                print(("ZEP parsing issue (bytes length={0}, channel={1}).".format(len(frame) if frame is not None else None, ch)))
                 continue
             break
 

--- a/killerbee/dev_sewio.py
+++ b/killerbee/dev_sewio.py
@@ -13,7 +13,12 @@ import os
 import time
 import struct
 import time
-import urllib.request, urllib.error, urllib.parse
+
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
 import re
 from socket import socket, AF_INET, SOCK_DGRAM, SOL_SOCKET, SO_REUSEADDR, timeout as error_timeout
 from struct import unpack
@@ -50,7 +55,7 @@ def ntp_to_system_time(secs, msecs):
 
 def getFirmwareVersion(ip):
     try:
-        html = urllib.request.urlopen("http://{0}/".format(ip))
+        html = urlopen("http://{0}/".format(ip))
         fw = re.search(r'Firmware version ([0-9.]+)', html.read())
         if fw is not None:
             return fw.group(1)
@@ -63,7 +68,7 @@ def getMacAddr(ip):
     Returns a string for the MAC address of the sniffer.
     '''
     try:
-        html = urllib.request.urlopen("http://{0}/".format(ip))
+        html = urlopen("http://{0}/".format(ip))
         # Yup, we're going to have to steal the status out of a JavaScript variable
         #var values = removeSSItag('<!--#pindex-->STOPPED,00:1a:b6:00:0a:a4,...
         res = re.search(r'<!--#pindex-->[A-Z]+,((?:[0-9a-f]{2}:){5}[0-9a-f]{2})', html.read())
@@ -153,7 +158,7 @@ class SEWIO:
             returns True if an HTTP 200 code was received.
         '''
         try:
-            html = urllib.request.urlopen("http://{0}/{1}".format(self.dev, path))
+            html = urlopen("http://{0}/{1}".format(self.dev, path))
             if fetch:
                 return html.read()
             else:

--- a/killerbee/dev_sl_beehive.py
+++ b/killerbee/dev_sl_beehive.py
@@ -10,7 +10,7 @@ import time
 import struct
 from datetime import datetime, date
 from datetime import time as dttime
-from kbutils import KBCapabilities, makeFCS
+from .kbutils import KBCapabilities, makeFCS
 
 MODE_NONE    = 0x01
 MODE_SNIFF   = 0x02
@@ -286,13 +286,13 @@ class SL_BEEHIVE:
         #print packet
         rssi, frame, validcrc = self.__dissect_pkt(packet)
         if not frame:
-            print "Error parsing stream received from device:", packet
+            print("Error parsing stream received from device:", packet)
 
         # Parse received data as <rssi>!<time>!<packtlen>!<frame>
         try:
             rssi = int(rssi)
         except:
-            print "Error parsing stream received from device:", packet
+            print("Error parsing stream received from device:", packet)
             return None
         #Return in a nicer dictionary format, so we don't have to reference by number indicies.
         #Note that 0,1,2 indicies inserted twice for backwards compatibility.

--- a/killerbee/dev_sl_nodetest.py
+++ b/killerbee/dev_sl_nodetest.py
@@ -10,7 +10,7 @@ import time
 import struct
 from datetime import datetime, date
 from datetime import time as dttime
-from kbutils import KBCapabilities, makeFCS
+from .kbutils import KBCapabilities, makeFCS
 
 MODE_NONE    = 0x01
 MODE_SNIFF   = 0x02
@@ -112,7 +112,7 @@ class SL_NODETEST:
         data = packet[1:].replace('{',' ').replace('}',' ').split()
         # should be 12 fields + payload length + payload
         if not data or not len(data[13:]) == int(data[12], 16):
-            print "Error parsing stream received from device (payload size error):", packet
+            print("Error parsing stream received from device (payload size error):", packet)
             return None
         # payload is in the form e.g. "0x03 0x08 0xA3 0xFF 0xFF 0xFF 0xFF 0x07" so we need to convert to a string
         frame = ''
@@ -120,7 +120,7 @@ class SL_NODETEST:
             try:
                 frame += chr(int(x, 16))
             except:
-                print "Error parsing stream received from device (invalid payload):", packet
+                print("Error parsing stream received from device (invalid payload):", packet)
                 return None
 
         # Parse other useful fields
@@ -130,7 +130,7 @@ class SL_NODETEST:
             validcrc = True
             frame += makeFCS(frame)
         except:
-            print "Error parsing stream received from device (invalid rssi or FCS build error):", packet
+            print("Error parsing stream received from device (invalid rssi or FCS build error):", packet)
             return None
         return [frame, validcrc, rssi]
 

--- a/killerbee/dev_telosb.py
+++ b/killerbee/dev_telosb.py
@@ -62,7 +62,7 @@ class TELOSB:
     # KillerBee expects the driver to implement this function
     #def get_dev_info(self, dev, bus):
     def get_dev_info(self):
-	'''
+        '''
         Returns device information in a list identifying the device.
         @rtype: List
         @return: List of 3 strings identifying device.

--- a/killerbee/dev_telosb.py
+++ b/killerbee/dev_telosb.py
@@ -9,8 +9,8 @@ import time
 import struct
 import time
 from datetime import datetime, timedelta
-from kbutils import KBCapabilities, makeFCS
-from GoodFETCCSPI import GoodFETCCSPI
+from .kbutils import KBCapabilities, makeFCS
+from .GoodFETCCSPI import GoodFETCCSPI
 
 CC2420_REG_SYNC = 0x14
 

--- a/killerbee/dev_zigduino.py
+++ b/killerbee/dev_zigduino.py
@@ -14,8 +14,8 @@ import time
 import struct
 import time
 from datetime import datetime, date, timedelta
-from kbutils import KBCapabilities, makeFCS
-from GoodFETatmel128 import GoodFETatmel128rfa1
+from .kbutils import KBCapabilities, makeFCS
+from .GoodFETatmel128 import GoodFETatmel128rfa1
 
 ATMEL_REG_SYNC = 0x0B
 

--- a/killerbee/dot154decode.py
+++ b/killerbee/dot154decode.py
@@ -109,7 +109,7 @@ class Dot154PacketParser:
         #    A[0] is for authenticity check, A[1] is for the first block of data,
         #    A[2] is for the 2nd block of data, if C > 16
         self.__crypt_A_i = []
-        for i in xrange(0, (1+1+(len(C)/16))):
+        for i in range(0, (1+1+(len(C)/16))):
             self.__crypt_A_i.append(flags + nonce + struct.pack(">H",i))
 
         # 5. Decrypt cipherText producing plainText (observed)
@@ -123,7 +123,7 @@ class Dot154PacketParser:
 
         # 7. Compute MIC (T) observed as S_0 XOR U
         T_obs = []
-        for i in xrange(0,len(S_0[0:8])):
+        for i in range(0,len(S_0[0:8])):
             T_obs.append((ord(S_0[i]) ^ ord(U[i])))
 
         # Convert T_obs back into a string (please, I need Python help)
@@ -152,7 +152,7 @@ class Dot154PacketParser:
 
         # 13. Calculate the MIC (T) calculated with CBC-MAC
         iv = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-        for i in xrange(0, len(B)/16):
+        for i in range(0, len(B)/16):
             crypt = AES.new(key, AES.MODE_CBC, iv)
             Bn = B[i*16:(i*16)+16]
             iv = crypt.encrypt(Bn)

--- a/killerbee/kbutils.py
+++ b/killerbee/kbutils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import sys
 

--- a/killerbee/kbutils.py
+++ b/killerbee/kbutils.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import sys
 
 # Import USB support depending on version of pyUSB
@@ -21,7 +21,7 @@ import random
 import inspect
 from struct import pack
 
-import config
+import killerbee.config as config
 
 # Known devices by USB ID:
 RZ_USB_VEND_ID      = 0x03EB
@@ -310,7 +310,7 @@ def devlist(vendor=None, product=None, gps=None, include=None):
 
     if include is not None:
         # Ugly nested load, so we don't load this class when unneeded!
-        import dev_sewio #use isSewio, getFirmwareVersion
+        from . import dev_sewio #use isSewio, getFirmwareVersion
         for ipaddr in filter(isIpAddr, include):
             if dev_sewio.isSewio(ipaddr):
                 devlist.append([ipaddr, "Sewio Open-Sniffer v{0}".format(dev_sewio.getFirmwareVersion(ipaddr)), dev_sewio.getMacAddr(ipaddr)])
@@ -357,7 +357,7 @@ def isgoodfetccspi(serialdev):
                 is the subtype, and is 0 for telosb devices and 1 for apimote devices.
     '''
     #TODO reduce code, perhaps into loop iterating over board configs
-    from GoodFETCCSPI import GoodFETCCSPI
+    from .GoodFETCCSPI import GoodFETCCSPI
     os.environ["platform"] = ""
     # First try tmote detection
     if config.DEV_ENABLE_TELOSB:
@@ -424,7 +424,7 @@ def iszigduino(serialdev):
     @returns: Boolean with the fist element==True if it is a goodfet atmel128 device.
     '''
     # TODO why does this only work every-other time zbid is invoked?
-    from GoodFETatmel128 import GoodFETatmel128rfa1
+    from .GoodFETatmel128 import GoodFETatmel128rfa1
     os.environ["platform"] = "zigduino"
     gf = GoodFETatmel128rfa1()
     try:
@@ -522,7 +522,7 @@ def search_usb(device):
     else:
         if ':' not in device:
             raise KBInterfaceError("USB device format expects <BusNumber>:<DeviceNumber>, but got {0} instead.".format(device))
-        busNum, devNum = map(int, device.split(':', 1))
+        busNum, devNum = list(map(int, device.split(':', 1)))
     if USBVER == 0:
         busses = usb.busses()
         for bus in busses:
@@ -561,7 +561,7 @@ def hexdump(src, length=16):
     '''
     FILTER = ''.join([(len(repr(chr(x))) == 3) and chr(x) or '.' for x in range(256)])
     result = []
-    for i in xrange(0, len(src), length):
+    for i in range(0, len(src), length):
        chars = src[i:i+length]
        hex = ' '.join(["%02x" % ord(x) for x in chars])
        printable = ''.join(["%s" % ((ord(x) <= 127 and FILTER[ord(x)]) or '.') for x in chars])
@@ -576,7 +576,7 @@ def randbytes(size):
     @param size: Length of random data to return.
     @rtype: String
     '''
-    return ''.join(chr(random.randrange(0,256)) for i in xrange(size))
+    return ''.join(chr(random.randrange(0,256)) for i in range(size))
 
 
 def randmac(length=8):
@@ -619,7 +619,7 @@ def makeFCS(data):
         little-endian order.
     '''
     crc = 0
-    for i in xrange(len(data)):
+    for i in range(len(data)):
         c = ord(data[i])
         #if (A PARITY BIT EXISTS): c = c & 127	#Mask off any parity bit
         q = (crc ^ c) & 15				#Do low-order 4 bits

--- a/killerbee/openear/__init__.py
+++ b/killerbee/openear/__init__.py
@@ -4,5 +4,5 @@
 #import struct
 #import bitstring
 
-from capture import *
+from .capture import *
 

--- a/killerbee/openear/capture.py
+++ b/killerbee/openear/capture.py
@@ -11,7 +11,7 @@ triggers = []
 #  initiate a pcap and online database capture.
 def startCapture(dev, capChan):
     timeLabel = datetime.utcnow().strftime('%Y%m%d-%H%M')
-    print 'Cap%s: Launching a capture on channel %s.' % (dev, capChan)
+    print('Cap%s: Launching a capture on channel %s.' % (dev, capChan))
     fname = 'zb_c%s_%s.pcap' % (capChan, timeLabel) #fname is -w equiv
     signal.signal(signal.SIGINT, interrupt)
     trigger = threading.Event()
@@ -39,7 +39,7 @@ class CaptureThread(threading.Thread):
         self.kb = KillerBee(device=self.devstring, datasource="Wardrive Live")
         self.kb.set_channel(self.channel)
         self.kb.sniffer_on()
-        print "Capturing on \'%s\' at channel %d." % (self.kb.get_dev_info()[0], self.channel)
+        print("Capturing on \'%s\' at channel %d." % (self.kb.get_dev_info()[0], self.channel))
         # loop capturing packets to dblog and file
         while not self.trigger.is_set():
             packet = self.kb.pnext()
@@ -52,5 +52,5 @@ class CaptureThread(threading.Thread):
         self.kb.sniffer_off()
         self.kb.close()
         self.pd.close()
-        print "%d packets captured" % self.packetcount
+        print("%d packets captured" % self.packetcount)
 

--- a/killerbee/openear/gps.py
+++ b/killerbee/openear/gps.py
@@ -1,4 +1,7 @@
-import gps, os, time
+import os
+import time
+
+import gps
 
 session = gps.gps()
 session.poll()
@@ -10,18 +13,18 @@ while 1:
     # a = altitude, d = date/time, m=mode,
     # o=postion/fix, s=status, y=satellites
 
-    print
-    print ' GPS reading'
-    print '----------------------------------------'
-    print 'fix         ' , ("NO_FIX","FIX","DGPS_FIX")[session.fix.mode - 1]
-    print 'latitude    ' , session.fix.latitude
-    print 'longitude   ' , session.fix.longitude
-    print 'time utc    ' , session.utc, session.fix.time
-    print 'altitude    ' , session.fix.altitude
+    print()
+    print(' GPS reading')
+    print('----------------------------------------')
+    print('fix         ' , ("NO_FIX","FIX","DGPS_FIX")[session.fix.mode - 1])
+    print('latitude    ' , session.fix.latitude)
+    print('longitude   ' , session.fix.longitude)
+    print('time utc    ' , session.utc, session.fix.time)
+    print('altitude    ' , session.fix.altitude)
 
-    print
-    print ' Satellites (total of', len(session.satellites) , ' in view)'
+    print()
+    print(' Satellites (total of', len(session.satellites) , ' in view)')
     for i in session.satellites:
-        print '\t', i
+        print('\t', i)
 
     time.sleep(3)

--- a/killerbee/openear/gps/__init__.py
+++ b/killerbee/openear/gps/__init__.py
@@ -6,8 +6,8 @@
 api_major_version = 4   # bumped on incompatible changes
 api_minor_version = 1   # bumped on compatible changes
 
-from gps import *
-from misc import *
+from .gps import *
+from .misc import *
 
 # The 'client' module exposes some C utility functions for Python clients.
 # The 'packet' module exposes the packet getter via a Python interface.

--- a/killerbee/openear/gps/client.py
+++ b/killerbee/openear/gps/client.py
@@ -31,7 +31,7 @@ class gpscommon:
                 host, port = host[:i], host[i+1:]
             try: port = int(port)
             except ValueError:
-                raise socket.error, "nonnumeric port"
+                raise socket.error("nonnumeric port")
         #if self.verbose > 0:
         #    print 'connect:', (host, port)
         msg = "getaddrinfo returns an empty list"
@@ -42,13 +42,13 @@ class gpscommon:
                 self.sock = socket.socket(af, socktype, proto)
                 #if self.debuglevel > 0: print 'connect:', (host, port)
                 self.sock.connect(sa)
-            except socket.error, msg:
+            except socket.error as msg:
                 #if self.debuglevel > 0: print 'connect fail:', (host, port)
                 self.close()
                 continue
             break
         if not self.sock:
-            raise socket.error, msg
+            raise socket.error(msg)
 
     def close(self):
         if self.sock:
@@ -128,14 +128,14 @@ class gpsjson(gpscommon):
         def asciify(d):
             "De-Unicodify everything so we can copy dicts into Python objects."
             t = {}
-            for (k, v) in d.items():
+            for (k, v) in list(d.items()):
                 ka = k.encode("ascii")
-                if type(v) == type(u"x"):
+                if type(v) == type("x"):
                     va = v.encode("ascii")
                 elif type(v) == type({}):
                     va = asciify(v)
                 elif type(v) == type([]):
-                    va = map(asciify, v)
+                    va = list(map(asciify, v))
                 else:
                     va = v
                 t[ka] = va
@@ -143,7 +143,7 @@ class gpsjson(gpscommon):
         self.data = dictwrapper(**asciify(json.loads(buf.strip(), encoding="ascii")))
         # Should be done for any other array-valued subobjects, too.
         if self.data["class"] == "SKY" and hasattr(self.data, "satellites"):
-            self.data.satellites = map(lambda x: dictwrapper(**x), self.data.satellites)
+            self.data.satellites = [dictwrapper(**x) for x in self.data.satellites]
 
     def stream(self, flags=0, outfile=None):
         "Control streaming reports from the daemon,"
@@ -182,7 +182,7 @@ class dictwrapper:
     def get(self, k, d=None):
         return self.__dict__.get(k, d)
     def keys(self):
-        return self.__dict__.keys()
+        return list(self.__dict__.keys())
     def __getitem__(self, key):
         "Emulate dictionary, for new-style interface."
         return self.__dict__[key]

--- a/killerbee/openear/gps/client.py
+++ b/killerbee/openear/gps/client.py
@@ -128,7 +128,7 @@ class gpsjson(gpscommon):
         def asciify(d):
             "De-Unicodify everything so we can copy dicts into Python objects."
             t = {}
-            for (k, v) in list(d.items()):
+            for (k, v) in d.items():
                 ka = k.encode("ascii")
                 if type(v) == type("x"):
                     va = v.encode("ascii")

--- a/killerbee/openear/gps/gps.py
+++ b/killerbee/openear/gps/gps.py
@@ -15,7 +15,7 @@
 # now live in a different module.
 #
 import time
-from client import *
+from .client import *
 
 NaN = float('nan')
 def isnan(x): return str(x) == 'nan'
@@ -235,14 +235,14 @@ class gps(gpsdata, gpsjson):
                     d1 = int(prefix.pop())
                     newsats = []
                     for i in range(d1):
-                        newsats.append(gps.satellite(*map(int, satellites[i].split())))
+                        newsats.append(gps.satellite(*list(map(int, satellites[i].split()))))
                     self.satellites = newsats
                     self.valid |= SATELLITE_SET
 
     def __oldstyle_shim(self):
         # The rest is backwards compatibility for the old interface
         def default(k, dflt, vbit=0):
-            if k not in self.data.keys():
+            if k not in list(self.data.keys()):
                 return dflt
             else:
                 self.valid |= vbit
@@ -283,7 +283,7 @@ class gps(gpsdata, gpsjson):
         elif self.data.get("class") == "SKY":
             for attrp in "xyvhpg":
                 setattr(self, attrp+"dop", default(attrp+"dop", NaN, DOP_SET))
-            if "satellites" in self.data.keys():
+            if "satellites" in list(self.data.keys()):
                 self.satellites = [] 
                 for sat in self.data['satellites']:
                     self.satellites.append(gps.satellite(PRN=sat['PRN'], elevation=sat['el'], azimuth=sat['az'], ss=sat['ss'], used=sat['used']))
@@ -314,7 +314,7 @@ class gps(gpsdata, gpsjson):
             self.valid |= PACKET_SET
         return 0
 
-    def next(self):
+    def __next__(self):
         if self.poll() == -1:
             raise StopIteration
         if hasattr(self, "data"):
@@ -356,7 +356,7 @@ if __name__ == '__main__':
         if switch == '-v':
             verbose = True
     if len(arguments) > 2:
-        print 'Usage: gps.py [-v] [host [port]]'
+        print('Usage: gps.py [-v] [host [port]]')
         sys.exit(1)
 
     opts = { "verbose" : verbose }
@@ -369,6 +369,6 @@ if __name__ == '__main__':
     session.set_raw_hook(lambda s: sys.stdout.write(s.strip() + "\n"))
     session.stream(WATCH_ENABLE|WATCH_NEWSTYLE)
     for report in session:
-        print report
+        print(report)
 
 # gps.py ends here

--- a/killerbee/openear/gps/gps.py
+++ b/killerbee/openear/gps/gps.py
@@ -322,6 +322,8 @@ class gps(gpsdata, gpsjson):
         else:
             return self.response
 
+    next = __next__()
+
     def stream(self, flags=0, outfile=None):
         "Ask gpsd to stream reports at your client."
         if (flags & (WATCH_JSON|WATCH_OLDSTYLE|WATCH_NMEA|WATCH_RAW)) == 0:

--- a/killerbee/openear/gps/misc.py
+++ b/killerbee/openear/gps/misc.py
@@ -50,8 +50,10 @@ def CalcRad(lat):
     r = r * 1000.0      # Convert to meters
     return r
 
-def EarthDistance((lat1, lon1), (lat2, lon2)):
+def EarthDistance(xxx_todo_changeme, xxx_todo_changeme1):
     "Distance in meters between two points specified in degrees."
+    (lat1, lon1) = xxx_todo_changeme
+    (lat2, lon2) = xxx_todo_changeme1
     x1 = CalcRad(lat1) * math.cos(Deg2Rad(lon1)) * math.sin(Deg2Rad(90-lat1))
     x2 = CalcRad(lat2) * math.cos(Deg2Rad(lon2)) * math.sin(Deg2Rad(90-lat2))
     y1 = CalcRad(lat1) * math.sin(Deg2Rad(lon1)) * math.sin(Deg2Rad(90-lat1))
@@ -67,8 +69,10 @@ def EarthDistance((lat1, lon1), (lat2, lon2)):
     elif a < -1: a = -1
     return CalcRad((lat1+lat2) / 2) * math.acos(a)
 
-def MeterOffset((lat1, lon1), (lat2, lon2)):
+def MeterOffset(xxx_todo_changeme2, xxx_todo_changeme3):
     "Return offset in meters of second arg from first."
+    (lat1, lon1) = xxx_todo_changeme2
+    (lat2, lon2) = xxx_todo_changeme3
     dx = EarthDistance((lat1, lon1), (lat1, lon2))
     dy = EarthDistance((lat1, lon1), (lat2, lon1))
     if lat1 < lat2: dy *= -1
@@ -83,7 +87,7 @@ def isotime(s):
         date = int(s)
         msec = s - date
         date = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(s))
-        return date + "." + `msec`[2:]
+        return date + "." + repr(msec)[2:]
     elif type(s) == type(""):
         if s[-1] == "Z":
             s = s[:-1]

--- a/killerbee/openear/gps/misc.py
+++ b/killerbee/openear/gps/misc.py
@@ -50,10 +50,10 @@ def CalcRad(lat):
     r = r * 1000.0      # Convert to meters
     return r
 
-def EarthDistance(xxx_todo_changeme, xxx_todo_changeme1):
+def EarthDistance(coords1, coords2):
     "Distance in meters between two points specified in degrees."
-    (lat1, lon1) = xxx_todo_changeme
-    (lat2, lon2) = xxx_todo_changeme1
+    (lat1, lon1) = coords1
+    (lat2, lon2) = coords2
     x1 = CalcRad(lat1) * math.cos(Deg2Rad(lon1)) * math.sin(Deg2Rad(90-lat1))
     x2 = CalcRad(lat2) * math.cos(Deg2Rad(lon2)) * math.sin(Deg2Rad(90-lat2))
     y1 = CalcRad(lat1) * math.sin(Deg2Rad(lon1)) * math.sin(Deg2Rad(90-lat1))
@@ -69,10 +69,10 @@ def EarthDistance(xxx_todo_changeme, xxx_todo_changeme1):
     elif a < -1: a = -1
     return CalcRad((lat1+lat2) / 2) * math.acos(a)
 
-def MeterOffset(xxx_todo_changeme2, xxx_todo_changeme3):
+def MeterOffset(coords1, coords2):
     "Return offset in meters of second arg from first."
-    (lat1, lon1) = xxx_todo_changeme2
-    (lat2, lon2) = xxx_todo_changeme3
+    (lat1, lon1) = coords1
+    (lat2, lon2) = coords2
     dx = EarthDistance((lat1, lon1), (lat1, lon2))
     dy = EarthDistance((lat1, lon1), (lat2, lon1))
     if lat1 < lat2: dy *= -1

--- a/killerbee/openear/scanner.py
+++ b/killerbee/openear/scanner.py
@@ -5,7 +5,11 @@
 from __future__ import print_function
 
 import datetime
-import queue
+
+try:
+    from queue import Queue, Empty
+except ImportError:
+    from Queue import Queue, Empty
 import signal
 import threading
 
@@ -37,7 +41,7 @@ class LocationThread(threading.Thread):
     def __init__(self):
         global active_queues
         threading.Thread.__init__(self)
-        self.mesg = queue.Queue()
+        self.mesg = Queue()
         active_queues.append(self.mesg)
 
     def run(self):
@@ -49,7 +53,7 @@ class LocationThread(threading.Thread):
         while(1):
             try:
                 message = self.mesg.get(timeout=.00001)
-            except queue.Empty:
+            except Empty:
                 pass
             if message == "shutdown":
                 break
@@ -75,7 +79,7 @@ class CaptureThread(threading.Thread):
     def __init__(self, dev, channel, pd):
         global active_queues
         threading.Thread.__init__(self)
-        self.mesg = queue.Queue()
+        self.mesg = Queue()
         active_queues.append(self.mesg)
         self.channel = channel
         self.freq = (channel - 10) * 5 + 2400
@@ -95,7 +99,7 @@ class CaptureThread(threading.Thread):
         while (True):
             try:
                 message = self.mesg.get(timeout=.00001)
-            except queue.Empty:
+            except Empty:
                 pass
             if message == "shutdown":
                 break

--- a/killerbee/openear/scanner.py
+++ b/killerbee/openear/scanner.py
@@ -2,12 +2,16 @@
 # ZBScanner
 # rmelgares 2011
 # Promiscious capture on multiple channels at once
+from __future__ import print_function
 
-import gps, time, os, signal, sys, operator, threading
-import string, socket, struct, datetime
+import datetime
+import queue
+import signal
+import threading
+
+import gps
 
 from killerbee import *
-import Queue
 
 # Globals
 session = ""
@@ -24,7 +28,7 @@ last_seen = ""
 
 def broadcast_event(data):
     ''' Send broadcast data to all active threads '''
-    print "\nShutting down threads." 
+    print("\nShutting down threads.") 
     for q in active_queues:
         q.put(data)
 
@@ -33,7 +37,7 @@ class LocationThread(threading.Thread):
     def __init__(self):
         global active_queues
         threading.Thread.__init__(self)
-        self.mesg = Queue.Queue()
+        self.mesg = queue.Queue()
         active_queues.append(self.mesg)
 
     def run(self):
@@ -45,7 +49,7 @@ class LocationThread(threading.Thread):
         while(1):
             try:
                 message = self.mesg.get(timeout=.00001)
-            except Queue.Empty:
+            except queue.Empty:
                 pass
             if message == "shutdown":
                 break
@@ -61,8 +65,8 @@ class LocationThread(threading.Thread):
             else:
                 end_time = datetime.datetime.utcnow()
                 elapsed_time = end_time - last_seen
-                print chr(0x1b) + "[2;5fElapsed time since last location change: %s" % str(elapsed_time) 
-            print chr(0x1b) + "[3;5fLat: %f, Long: %f, Alt: %f." % (latitude, longitude, altitude)
+                print(chr(0x1b) + "[2;5fElapsed time since last location change: %s" % str(elapsed_time)) 
+            print(chr(0x1b) + "[3;5fLat: %f, Long: %f, Alt: %f." % (latitude, longitude, altitude))
             time.sleep(1)
  
 
@@ -71,7 +75,7 @@ class CaptureThread(threading.Thread):
     def __init__(self, dev, channel, pd):
         global active_queues
         threading.Thread.__init__(self)
-        self.mesg = Queue.Queue()
+        self.mesg = queue.Queue()
         active_queues.append(self.mesg)
         self.channel = channel
         self.freq = (channel - 10) * 5 + 2400
@@ -91,7 +95,7 @@ class CaptureThread(threading.Thread):
         while (True):
             try:
                 message = self.mesg.get(timeout=.00001)
-            except Queue.Empty:
+            except queue.Empty:
                 pass
             if message == "shutdown":
                 break
@@ -100,19 +104,19 @@ class CaptureThread(threading.Thread):
                 self.packetcount+=1
                 if arg_gps:
                     gpsdata = (longitude, latitude, altitude)
-                    self.pd.pcap_dump(packet['bytes'], ant_dbm=packet['dbm'], freq_mhz=self.freq, location=map(float, gpsdata))
+                    self.pd.pcap_dump(packet['bytes'], ant_dbm=packet['dbm'], freq_mhz=self.freq, location=list(map(float, gpsdata)))
                     if arg_db:self.kb.dblog.add_packet(full=packet, location=gpsdata)
                 else:
                     self.pd.pcap_dump(packet['bytes'])
                     if arg_db:self.kb.dblog.add_packet(full=packet)
-                print chr(0x1b) + "[%d;5fChannel %d: %d packets captured." % (self.channel - 6, self.channel, self.packetcount)
+                print(chr(0x1b) + "[%d;5fChannel %d: %d packets captured." % (self.channel - 6, self.channel, self.packetcount))
         # trigger threading.Event set to false, so shutdown thread
         if arg_verbose:
-            print "%s on channel %d shutting down..." % (threading.currentThread().getName(), self.channel)
+            print("%s on channel %d shutting down..." % (threading.currentThread().getName(), self.channel))
         self.kb.sniffer_off()
         self.kb.close()
         self.pd.close()
-        print "%d packets captured on channel %d" % (self.packetcount, self.channel)
+        print("%d packets captured on channel %d" % (self.packetcount, self.channel))
 
 def signal_handler(signal, frame):
     ''' Signal handler called on keyboard interrupt to exit threads and exit scanner script'''
@@ -146,28 +150,28 @@ def main(args):
     else:
         kbdev_info = kbutils.devlist()
     channel = 11
-    print "Found %d devices." % len(kbdev_info)
+    print("Found %d devices." % len(kbdev_info))
     if len(kbdev_info) < 1:
         exit(1)
     if arg_gps == True:
-        print "Initializing GPS device %s ... "% (arg_gps_devstring),
+        print("Initializing GPS device %s ... "% (arg_gps_devstring), end=' ')
         session = gps.gps()
         session.poll()
         session.stream()
-        print "Waiting for fix... ",
+        print("Waiting for fix... ", end=' ')
         while(session.fix.mode == 1):
             session.poll()
-        print "Fix acquired!"
+        print("Fix acquired!")
         t = LocationThread()
         t.start()
     time.sleep(2)
     for i in range(0, len(kbdev_info)):
             if kbdev_info[i][0] == arg_gps_devstring:
-                print "Skipping device %s" % arg_gps_devstring
+                print("Skipping device %s" % arg_gps_devstring)
             else:
-                print 'Device at %s: \'%s\'' % (kbdev_info[i][0], kbdev_info[i][1])
+                print('Device at %s: \'%s\'' % (kbdev_info[i][0], kbdev_info[i][1]))
                 if channel <= 26:
-                    print '\tAssigning to channel %d.' % channel
+                    print('\tAssigning to channel %d.' % channel)
                 timeLabel = datetime.datetime.utcnow().strftime('%Y%m%d-%H%M')
                 fname = 'zb_c%s_%s.pcap' % (channel, timeLabel) #fname is -w equiv
                 pcap = PcapDumper(DLT_IEEE802_15_4, fname, ppi=arg_ppi)
@@ -175,5 +179,5 @@ def main(args):
                 t.start()
                 channel += 1
     os.system('clear')
-    print chr(0x1b) + "[1;5fLive Stats:"
+    print(chr(0x1b) + "[1;5fLive Stats:")
     while True: pass

--- a/killerbee/pcapdump.py
+++ b/killerbee/pcapdump.py
@@ -9,7 +9,7 @@ PCAPH_THISZONE  = 0
 PCAPH_SIGFIGS   = 0
 PCAPH_SNAPLEN   = 65535
 
-DOT11COMMON_TAG = 0o00002
+DOT11COMMON_TAG = 2
 GPS_TAG		= 30002
 
 class PcapReader:
@@ -103,6 +103,13 @@ class PcapReader:
         return [rechdr, frame]
 
 
+def is_string(s):
+    try:
+        return isinstance(s, basestring)
+    except NameError:
+        return isinstance(s, str)
+
+
 class PcapDumper:
     def __init__(self, datalink, savefile, ppi = False):
         '''
@@ -118,7 +125,7 @@ class PcapDumper:
         if ppi: from killerbee.pcapdlt import DLT_PPI
         self.ppi = ppi
 
-        if isinstance(savefile, str):
+        if is_string(savefile):
             self.__fh = open(savefile, mode='wb')
         elif hasattr(savefile, 'write'):
             self.__fh = savefile

--- a/killerbee/pcapdump.py
+++ b/killerbee/pcapdump.py
@@ -9,7 +9,7 @@ PCAPH_THISZONE  = 0
 PCAPH_SIGFIGS   = 0
 PCAPH_SNAPLEN   = 65535
 
-DOT11COMMON_TAG = 000002
+DOT11COMMON_TAG = 0o00002
 GPS_TAG		= 30002
 
 class PcapReader:
@@ -118,7 +118,7 @@ class PcapDumper:
         if ppi: from killerbee.pcapdlt import DLT_PPI
         self.ppi = ppi
 
-        if isinstance(savefile, basestring):
+        if isinstance(savefile, str):
             self.__fh = open(savefile, mode='wb')
         elif hasattr(savefile, 'write'):
             self.__fh = savefile
@@ -263,7 +263,7 @@ class PcapDumper:
         # Specially for handling FIFO needs:
         try:
             self.__fh.flush()
-        except IOError, e:
+        except IOError as e:
             raise e
 
 

--- a/killerbee/scapy_extensions.py
+++ b/killerbee/scapy_extensions.py
@@ -15,7 +15,7 @@ from scapy.all import *
 from killerbee import *
 
 import os, time, struct
-from kbutils import randmac
+from .kbutils import randmac
 
 import logging
 log_killerbee = logging.getLogger('scapy.killerbee')
@@ -135,7 +135,7 @@ def kbsendp(pkt, channel = None, inter = 0, loop = 0, iface = None, count = None
 
     pkts_out = __kb_send(kb, pkt, inter = inter, loop = loop, count = count, verbose = verbose, realtime = realtime)
     if verbose:
-        print "\nSent %i packets." % pkts_out
+        print("\nSent %i packets." % pkts_out)
     kb.close()
 
 @conf.commands.register
@@ -179,11 +179,11 @@ def kbsrp(pkt, channel = None, page = 0, inter = 0, count = 0, iface = None, sto
 
     pkts_out = __kb_send(kb, pkt, inter = inter, loop = 0, count = None, verbose = verbose, realtime = realtime)
     if verbose:
-        print "\nSent %i packets." % pkts_out
+        print("\nSent %i packets." % pkts_out)
 
     pkts_in = __kb_recv(kb, count = count, store = store, prn = prn, lfilter = lfilter, verbose = verbose, timeout = timeout)
     if verbose:
-        print "\nReceived %i packets." % len(pkts_in)
+        print("\nReceived %i packets." % len(pkts_in))
     return plist.PacketList(pkts_in, 'Results')
 
 @conf.commands.register
@@ -315,9 +315,9 @@ def kbkeysearch(packet, searchdata, ispath = True, skipfcs = True, raw = False):
     while (offset < (searchdatalen - 16)):
         if d.decrypt(packet, searchdata[offset:offset+16]) != '':
             if raw:
-                return ''.join(searchdata[offset + i] for i in xrange(0, 16))
+                return ''.join(searchdata[offset + i] for i in range(0, 16))
             else:
-                return ':'.join("%02x" % ord(searchdata[offset + i]) for i in xrange(0, 16))
+                return ':'.join("%02x" % ord(searchdata[offset + i]) for i in range(0, 16))
         else:
             offset+=1
     return None
@@ -389,9 +389,9 @@ def kbgetnetworkkey(pkts):
             dst_mac_bytes = []
             src_mac_bytes = []
             key = {}
-            key['key'] = ':'.join("%02x" % ord(networkkey[x]) for x in xrange(16))
-            key['dst'] = ':'.join("%02x" % ord(destaddr[x]) for x in xrange(8))
-            key['src'] = ':'.join("%02x" % ord(srcaddr[x]) for x in xrange(8))
+            key['key'] = ':'.join("%02x" % ord(networkkey[x]) for x in range(16))
+            key['dst'] = ':'.join("%02x" % ord(destaddr[x]) for x in range(8))
+            key['src'] = ':'.join("%02x" % ord(srcaddr[x]) for x in range(8))
             return key
         except:
             continue
@@ -467,13 +467,13 @@ def kbdecrypt(source_pkt, key = None, verbose = None, doMicCheck = False):
     (payload, micCheck) = zigbee_crypt.decrypt_ccm(key, nonce, pkt.mic, encrypted, zigbeeData)
 
     if verbose > 2:
-        print "Decrypt Details:"
-        print "\tKey:            " + key.encode('hex')
-        print "\tNonce:          " + nonce.encode('hex')
-        print "\tZigbeeData:     " + zigbeeData.encode('hex')
-        print "\tDecrypted Data: " + payload.encode('hex')
-        print "\tEncrypted Data: " + encrypted.encode('hex')
-        print "\tMic:            " + pkt.mic.encode('hex')
+        print("Decrypt Details:")
+        print("\tKey:            " + key.encode('hex'))
+        print("\tNonce:          " + nonce.encode('hex'))
+        print("\tZigbeeData:     " + zigbeeData.encode('hex'))
+        print("\tDecrypted Data: " + payload.encode('hex'))
+        print("\tEncrypted Data: " + encrypted.encode('hex'))
+        print("\tMic:            " + pkt.mic.encode('hex'))
 
     frametype = pkt[ZigbeeNWK].frametype
     if frametype == 0 and micCheck == 1:
@@ -551,13 +551,13 @@ def kbencrypt(source_pkt, data, key = None, verbose = None):
     (payload, mic) = zigbee_crypt.encrypt_ccm(key, nonce, miclen, decrypted, zigbeeData)
 
     if verbose > 2:
-        print "Encrypt Details:"
-        print "\tKey:            " + key.encode('hex')
-        print "\tNonce:          " + nonce.encode('hex')
-        print "\tZigbeeData:     " + zigbeeData.encode('hex')
-        print "\tDecrypted Data: " + decrypted.encode('hex')
-        print "\tEncrypted Data: " + payload.encode('hex')
-        print "\tMic:            " + mic.encode('hex')
+        print("Encrypt Details:")
+        print("\tKey:            " + key.encode('hex'))
+        print("\tNonce:          " + nonce.encode('hex'))
+        print("\tZigbeeData:     " + zigbeeData.encode('hex'))
+        print("\tDecrypted Data: " + decrypted.encode('hex'))
+        print("\tEncrypted Data: " + payload.encode('hex'))
+        print("\tMic:            " + mic.encode('hex'))
 
     # According to comments in e.g. https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-zbee-security.c nwk_seclevel is not used any more but
     # we should reconstruct and return what was asked for anyway.

--- a/killerbee/zbwardrive/__init__.py
+++ b/killerbee/zbwardrive/__init__.py
@@ -3,8 +3,8 @@
 # ZigBee/802.15.4 WarDriving Platform
 
 from killerbee import *
-from db import *
-from scanning import doScan
-from zbwardrive import startScan, gpsdPoller
-from capture import *
+from .db import *
+from .scanning import doScan
+from .zbwardrive import startScan, gpsdPoller
+from .capture import *
 

--- a/killerbee/zbwardrive/capture.py
+++ b/killerbee/zbwardrive/capture.py
@@ -20,9 +20,9 @@ def startCapture(zbdb, channel, dblog=False, gps=False):
     capChan = channel
     key = "CH%d" % channel
     if nextDev == None:
-        print 'Cap%s: No free device to use for capture.' % key
+        print('Cap%s: No free device to use for capture.' % key)
         return None
-    print 'Cap%s: Launching a capture on channel %s.' % (key, capChan)
+    print('Cap%s: Launching a capture on channel %s.' % (key, capChan))
     signal.signal(signal.SIGINT, interrupt)
     trigger = threading.Event()
     triggers.append(trigger)
@@ -62,7 +62,7 @@ class CaptureThread(threading.Thread):
             self.kb = KillerBee(device=self.devstring)
         self.kb.set_channel(self.channel)
         self.kb.sniffer_on()
-        print "Capturing on \'%s\' at channel %d." % (self.kb.get_dev_info()[0], self.channel)
+        print("Capturing on \'%s\' at channel %d." % (self.kb.get_dev_info()[0], self.channel))
         # loop capturing packets to dblog and file
         while not self.trigger.is_set():
             packet = self.kb.pnext()
@@ -94,5 +94,5 @@ class CaptureThread(threading.Thread):
         self.kb.sniffer_off()
         self.kb.close()
         self.pd.close()
-        print "%d packets captured on channel %d." % (self.packetcount, self.channel)
+        print("%d packets captured on channel %d." % (self.packetcount, self.channel))
 

--- a/killerbee/zbwardrive/db.py
+++ b/killerbee/zbwardrive/db.py
@@ -25,7 +25,7 @@ class ZBScanDB:
     # Returns the devid of a device marked 'Free',
     # or None if there are no Free devices in the DB.
     def get_devices_nextFree(self):
-        for devid, dev in list(self.devices.items()):
+        for devid, dev in self.devices.items():
             if dev[2] == 'Free':
                 return devid
 
@@ -64,7 +64,7 @@ class ZBScanDB:
         '''
         if chan == None: raise Exception("None given for channel number")
         elif chan not in self.channels: raise Exception("Invalid channel")
-        for dev in list(self.devices.values()):
+        for dev in self.devices.values():
             if dev[3] == chan and dev[2] == 'Capture':
                 return True
         return False

--- a/killerbee/zbwardrive/db.py
+++ b/killerbee/zbwardrive/db.py
@@ -25,7 +25,7 @@ class ZBScanDB:
     # Returns the devid of a device marked 'Free',
     # or None if there are no Free devices in the DB.
     def get_devices_nextFree(self):
-        for devid, dev in self.devices.items():
+        for devid, dev in list(self.devices.items()):
             if dev[2] == 'Free':
                 return devid
 
@@ -64,7 +64,7 @@ class ZBScanDB:
         '''
         if chan == None: raise Exception("None given for channel number")
         elif chan not in self.channels: raise Exception("Invalid channel")
-        for dev in self.devices.values():
+        for dev in list(self.devices.values()):
             if dev[3] == chan and dev[2] == 'Capture':
                 return True
         return False

--- a/killerbee/zbwardrive/gps/__init__.py
+++ b/killerbee/zbwardrive/gps/__init__.py
@@ -6,8 +6,8 @@
 api_major_version = 4   # bumped on incompatible changes
 api_minor_version = 1   # bumped on compatible changes
 
-from gps import *
-from misc import *
+from .gps import *
+from .misc import *
 
 # The 'client' module exposes some C utility functions for Python clients.
 # The 'packet' module exposes the packet getter via a Python interface.

--- a/killerbee/zbwardrive/gps/client.py
+++ b/killerbee/zbwardrive/gps/client.py
@@ -31,7 +31,7 @@ class gpscommon:
                 host, port = host[:i], host[i+1:]
             try: port = int(port)
             except ValueError:
-                raise socket.error, "nonnumeric port"
+                raise socket.error("nonnumeric port")
         #if self.verbose > 0:
         #    print 'connect:', (host, port)
         msg = "getaddrinfo returns an empty list"
@@ -42,13 +42,13 @@ class gpscommon:
                 self.sock = socket.socket(af, socktype, proto)
                 #if self.debuglevel > 0: print 'connect:', (host, port)
                 self.sock.connect(sa)
-            except socket.error, msg:
+            except socket.error as msg:
                 #if self.debuglevel > 0: print 'connect fail:', (host, port)
                 self.close()
                 continue
             break
         if not self.sock:
-            raise socket.error, msg
+            raise socket.error(msg)
 
     def close(self):
         if self.sock:
@@ -128,14 +128,14 @@ class gpsjson(gpscommon):
         def asciify(d):
             "De-Unicodify everything so we can copy dicts into Python objects."
             t = {}
-            for (k, v) in d.items():
+            for (k, v) in list(d.items()):
                 ka = k.encode("ascii")
-                if type(v) == type(u"x"):
+                if type(v) == type("x"):
                     va = v.encode("ascii")
                 elif type(v) == type({}):
                     va = asciify(v)
                 elif type(v) == type([]):
-                    va = map(asciify, v)
+                    va = list(map(asciify, v))
                 else:
                     va = v
                 t[ka] = va
@@ -143,7 +143,7 @@ class gpsjson(gpscommon):
         self.data = dictwrapper(**asciify(json.loads(buf.strip(), encoding="ascii")))
         # Should be done for any other array-valued subobjects, too.
         if self.data["class"] == "SKY" and hasattr(self.data, "satellites"):
-            self.data.satellites = map(lambda x: dictwrapper(**x), self.data.satellites)
+            self.data.satellites = [dictwrapper(**x) for x in self.data.satellites]
 
     def stream(self, flags=0, outfile=None):
         "Control streaming reports from the daemon,"
@@ -182,7 +182,7 @@ class dictwrapper:
     def get(self, k, d=None):
         return self.__dict__.get(k, d)
     def keys(self):
-        return self.__dict__.keys()
+        return list(self.__dict__.keys())
     def __getitem__(self, key):
         "Emulate dictionary, for new-style interface."
         return self.__dict__[key]

--- a/killerbee/zbwardrive/gps/client.py
+++ b/killerbee/zbwardrive/gps/client.py
@@ -128,9 +128,9 @@ class gpsjson(gpscommon):
         def asciify(d):
             "De-Unicodify everything so we can copy dicts into Python objects."
             t = {}
-            for (k, v) in list(d.items()):
+            for (k, v) in d.items():
                 ka = k.encode("ascii")
-                if type(v) == type("x"):
+                if type(v) == type(u"x"):
                     va = v.encode("ascii")
                 elif type(v) == type({}):
                     va = asciify(v)

--- a/killerbee/zbwardrive/gps/gps.py
+++ b/killerbee/zbwardrive/gps/gps.py
@@ -15,7 +15,7 @@
 # now live in a different module.
 #
 import time
-from client import *
+from .client import *
 
 NaN = float('nan')
 def isnan(x): return str(x) == 'nan'
@@ -235,14 +235,14 @@ class gps(gpsdata, gpsjson):
                     d1 = int(prefix.pop())
                     newsats = []
                     for i in range(d1):
-                        newsats.append(gps.satellite(*map(int, satellites[i].split())))
+                        newsats.append(gps.satellite(*list(map(int, satellites[i].split()))))
                     self.satellites = newsats
                     self.valid |= SATELLITE_SET
 
     def __oldstyle_shim(self):
         # The rest is backwards compatibility for the old interface
         def default(k, dflt, vbit=0):
-            if k not in self.data.keys():
+            if k not in list(self.data.keys()):
                 return dflt
             else:
                 self.valid |= vbit
@@ -283,7 +283,7 @@ class gps(gpsdata, gpsjson):
         elif self.data.get("class") == "SKY":
             for attrp in "xyvhpg":
                 setattr(self, attrp+"dop", default(attrp+"dop", NaN, DOP_SET))
-            if "satellites" in self.data.keys():
+            if "satellites" in list(self.data.keys()):
                 self.satellites = [] 
                 for sat in self.data['satellites']:
                     self.satellites.append(gps.satellite(PRN=sat['PRN'], elevation=sat['el'], azimuth=sat['az'], ss=sat['ss'], used=sat['used']))
@@ -314,7 +314,7 @@ class gps(gpsdata, gpsjson):
             self.valid |= PACKET_SET
         return 0
 
-    def next(self):
+    def __next__(self):
         if self.poll() == -1:
             raise StopIteration
         if hasattr(self, "data"):
@@ -356,7 +356,7 @@ if __name__ == '__main__':
         if switch == '-v':
             verbose = True
     if len(arguments) > 2:
-        print 'Usage: gps.py [-v] [host [port]]'
+        print('Usage: gps.py [-v] [host [port]]')
         sys.exit(1)
 
     opts = { "verbose" : verbose }
@@ -369,6 +369,6 @@ if __name__ == '__main__':
     session.set_raw_hook(lambda s: sys.stdout.write(s.strip() + "\n"))
     session.stream(WATCH_ENABLE|WATCH_NEWSTYLE)
     for report in session:
-        print report
+        print(report)
 
 # gps.py ends here

--- a/killerbee/zbwardrive/gps/gps.py
+++ b/killerbee/zbwardrive/gps/gps.py
@@ -322,6 +322,8 @@ class gps(gpsdata, gpsjson):
         else:
             return self.response
 
+    next = __next__
+
     def stream(self, flags=0, outfile=None):
         "Ask gpsd to stream reports at your client."
         if (flags & (WATCH_JSON|WATCH_OLDSTYLE|WATCH_NMEA|WATCH_RAW)) == 0:

--- a/killerbee/zbwardrive/gps/misc.py
+++ b/killerbee/zbwardrive/gps/misc.py
@@ -50,8 +50,10 @@ def CalcRad(lat):
     r = r * 1000.0      # Convert to meters
     return r
 
-def EarthDistance((lat1, lon1), (lat2, lon2)):
+def EarthDistance(xxx_todo_changeme, xxx_todo_changeme1):
     "Distance in meters between two points specified in degrees."
+    (lat1, lon1) = xxx_todo_changeme
+    (lat2, lon2) = xxx_todo_changeme1
     x1 = CalcRad(lat1) * math.cos(Deg2Rad(lon1)) * math.sin(Deg2Rad(90-lat1))
     x2 = CalcRad(lat2) * math.cos(Deg2Rad(lon2)) * math.sin(Deg2Rad(90-lat2))
     y1 = CalcRad(lat1) * math.sin(Deg2Rad(lon1)) * math.sin(Deg2Rad(90-lat1))
@@ -67,8 +69,10 @@ def EarthDistance((lat1, lon1), (lat2, lon2)):
     elif a < -1: a = -1
     return CalcRad((lat1+lat2) / 2) * math.acos(a)
 
-def MeterOffset((lat1, lon1), (lat2, lon2)):
+def MeterOffset(xxx_todo_changeme2, xxx_todo_changeme3):
     "Return offset in meters of second arg from first."
+    (lat1, lon1) = xxx_todo_changeme2
+    (lat2, lon2) = xxx_todo_changeme3
     dx = EarthDistance((lat1, lon1), (lat1, lon2))
     dy = EarthDistance((lat1, lon1), (lat2, lon1))
     if lat1 < lat2: dy *= -1
@@ -83,7 +87,7 @@ def isotime(s):
         date = int(s)
         msec = s - date
         date = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(s))
-        return date + "." + `msec`[2:]
+        return date + "." + repr(msec)[2:]
     elif type(s) == type(""):
         if s[-1] == "Z":
             s = s[:-1]

--- a/killerbee/zbwardrive/gps/misc.py
+++ b/killerbee/zbwardrive/gps/misc.py
@@ -50,10 +50,10 @@ def CalcRad(lat):
     r = r * 1000.0      # Convert to meters
     return r
 
-def EarthDistance(xxx_todo_changeme, xxx_todo_changeme1):
+def EarthDistance(coords1, coords2):
     "Distance in meters between two points specified in degrees."
-    (lat1, lon1) = xxx_todo_changeme
-    (lat2, lon2) = xxx_todo_changeme1
+    (lat1, lon1) = coords1
+    (lat2, lon2) = coords2
     x1 = CalcRad(lat1) * math.cos(Deg2Rad(lon1)) * math.sin(Deg2Rad(90-lat1))
     x2 = CalcRad(lat2) * math.cos(Deg2Rad(lon2)) * math.sin(Deg2Rad(90-lat2))
     y1 = CalcRad(lat1) * math.sin(Deg2Rad(lon1)) * math.sin(Deg2Rad(90-lat1))
@@ -69,10 +69,10 @@ def EarthDistance(xxx_todo_changeme, xxx_todo_changeme1):
     elif a < -1: a = -1
     return CalcRad((lat1+lat2) / 2) * math.acos(a)
 
-def MeterOffset(xxx_todo_changeme2, xxx_todo_changeme3):
+def MeterOffset(coords1, coords2):
     "Return offset in meters of second arg from first."
-    (lat1, lon1) = xxx_todo_changeme2
-    (lat2, lon2) = xxx_todo_changeme3
+    (lat1, lon1) = coords1
+    (lat2, lon2) = coords2
     dx = EarthDistance((lat1, lon1), (lat1, lon2))
     dy = EarthDistance((lat1, lon1), (lat2, lon1))
     if lat1 < lat2: dy *= -1

--- a/killerbee/zbwardrive/testGPS.py
+++ b/killerbee/zbwardrive/testGPS.py
@@ -1,4 +1,7 @@
-import gps, os, time
+import os
+import time
+
+import gps
 
 session = gps.gps()
 session.poll()
@@ -10,18 +13,18 @@ while 1:
     # a = altitude, d = date/time, m=mode,
     # o=postion/fix, s=status, y=satellites
 
-    print
-    print ' GPS reading'
-    print '----------------------------------------'
-    print 'fix         ' , ("NO_FIX","FIX","DGPS_FIX")[session.fix.mode - 1]
-    print 'latitude    ' , session.fix.latitude
-    print 'longitude   ' , session.fix.longitude
-    print 'time utc    ' , session.utc, session.fix.time
-    print 'altitude    ' , session.fix.altitude
+    print()
+    print(' GPS reading')
+    print('----------------------------------------')
+    print('fix         ' , ("NO_FIX","FIX","DGPS_FIX")[session.fix.mode - 1])
+    print('latitude    ' , session.fix.latitude)
+    print('longitude   ' , session.fix.longitude)
+    print('time utc    ' , session.utc, session.fix.time)
+    print('altitude    ' , session.fix.altitude)
 
-    print
-    print ' Satellites (total of', len(session.satellites) , ' in view)'
+    print()
+    print(' Satellites (total of', len(session.satellites) , ' in view)')
     for i in session.satellites:
-        print '\t', i
+        print('\t', i)
 
     time.sleep(3)

--- a/killerbee/zbwardrive/zbwardrive.py
+++ b/killerbee/zbwardrive/zbwardrive.py
@@ -8,8 +8,8 @@ from time import sleep
 from usb import USBError
 
 from killerbee import KillerBee, kbutils
-from db import ZBScanDB
-from scanning import doScan
+from .db import ZBScanDB
+from .scanning import doScan
 
 # GPS Poller
 def gpsdPoller(currentGPS):
@@ -17,7 +17,7 @@ def gpsdPoller(currentGPS):
     @type currentGPS multiprocessing.Manager dict manager
     @arg currentGPS store relavent pieces of up-to-date GPS info
     '''
-    import gps
+    from . import gps
     gpsd = gps.gps()
     gpsd.poll()
     gpsd.stream()
@@ -38,10 +38,10 @@ def gpsdPoller(currentGPS):
                 currentGPS['lng'] = lng
                 currentGPS['alt'] = alt
             else:
-                print "Waiting for a GPS fix."
+                print("Waiting for a GPS fix.")
                 #TODO timeout lat/lng/alt values if too old...?
     except KeyboardInterrupt:
-        print "Got KeyboardInterrupt in gpsdPoller, returning."
+        print("Got KeyboardInterrupt in gpsdPoller, returning.")
         return
 
 # startScan
@@ -50,18 +50,18 @@ def gpsdPoller(currentGPS):
 def startScan(zbdb, currentGPS, verbose=False, dblog=False, agressive=False, include=[], ignore=None):
     try:
         kb = KillerBee()
-    except USBError, e:
+    except USBError as e:
         if e.args[0].find('Operation not permitted') >= 0:
-            print 'Error: Permissions error, try running using sudo.'
+            print('Error: Permissions error, try running using sudo.')
         else:
-            print 'Error: USBError:', e
+            print('Error: USBError:', e)
         return False
-    except Exception, e:
+    except Exception as e:
         #print 'Error: Missing KillerBee USB hardware:', e
-        print 'Error: Issue starting KillerBee instance:', e
+        print('Error: Issue starting KillerBee instance:', e)
         return False
     for kbdev in kbutils.devlist(gps=ignore, include=include):
-        print 'Found device at %s: \'%s\'' % (kbdev[0], kbdev[1])
+        print('Found device at %s: \'%s\'' % (kbdev[0], kbdev[1]))
         zbdb.store_devices(
             kbdev[0], #devid
             kbdev[1], #devstr

--- a/tools/kbbootloader
+++ b/tools/kbbootloader
@@ -18,24 +18,24 @@ def test_functions():
         sleep(1)
         kb = KillerBee()
     except:
-        print 'Could not activate bootloader - may be already running...'
+        print('Could not activate bootloader - may be already running...')
     
     # Get the bootloader version
-    print 'version:',
+    print('version:', end=' ')
     ver = kb.get_bootloader_version()
-    print '%02x - %02x' % (ver[0], ver[1])
+    print('%02x - %02x' % (ver[0], ver[1]))
 
     # Get AT90USB1287 signature
-    print 'AT90USB1287 signature:', 
+    print('AT90USB1287 signature:', end=' ') 
     sig = kb.get_bootloader_signature()
-    print '%02x - %02x - %02x' % (sig[0], sig[1], sig[2])
+    print('%02x - %02x - %02x' % (sig[0], sig[1], sig[2]))
 
     # Get identifier string
-    print 'identifier string',
+    print('identifier string', end=' ')
     arr = kb.bootloader_sign_on()
     # return is an array of bytes with 1st byte being length
     st = ''.join([chr(x) for x in arr[1:]])
-    print "(%d bytes):" % arr[0], st
+    print("(%d bytes):" % arr[0], st)
 
     # Read the fuses
     #fuses = kb.read_fuses()
@@ -76,6 +76,6 @@ if __name__ == '__main__':
         kb = KillerBee()
         kb.enter_bootloader()
     except:
-	print 'Could not activate bootloader - may be already running...'
+	print('Could not activate bootloader - may be already running...')
 
 

--- a/tools/kbbootloader
+++ b/tools/kbbootloader
@@ -4,6 +4,7 @@
 # Adam Laurie / rfidiot, 2018
 # adam@algroup.co.uk
 
+from __future__ import print_function
 import sys
 from killerbee import *
 from time import sleep

--- a/tools/zbassocflood
+++ b/tools/zbassocflood
@@ -8,7 +8,7 @@ from killerbee import *
 
 
 def usage():
-    print >>sys.stderr, """
+    print("""
 zbassocflood: Transmit a flood of associate requests to a target network.
 jwright@willhackforsushi.com
 
@@ -16,13 +16,13 @@ Usage: zbassocflood [-pcDis] [-i devnumstring] [-p PANID] [-c channel]
                         [-s per-packet delay/float]
 
 e.x. zbassocflood -p 0xBAAD -c 11 -s 0.1
-    """
+    """, file=sys.stderr)
 
 def interrupt(signum, frame):
     global kb
     global txcount
     kb.close()
-    print "\nSent %d associate requests."%txcount
+    print("\nSent %d associate requests."%txcount)
     sys.exit(0)
 
 # Watch for an association response
@@ -121,7 +121,7 @@ if __name__ == '__main__':
     kb = KillerBee(device=arg_devstring)
     signal.signal(signal.SIGINT, interrupt)
 
-    print "zbassocflood: Transmitting and receiving on interface \'%s\'" % kb.get_dev_info()[0]
+    print("zbassocflood: Transmitting and receiving on interface \'%s\'" % kb.get_dev_info()[0])
     
     # Sequence number of assoc frame
     kb.set_channel(arg_channel)
@@ -164,17 +164,17 @@ if __name__ == '__main__':
 
             # Send the data request frame
             kb.inject(datareqinj)
-        except Exception, e:
-            print "ERROR: Unable to inject packet"
-            print e
+        except Exception as e:
+            print("ERROR: Unable to inject packet")
+            print(e)
             sys.exit(-1)
 
         try:
             # Listen for the ACK response
             seq = watchforaresp(kb, arg_framedelay*10)
-        except Exception, e:
-            print "ERROR: Unable to handle response processing."
-            print e
+        except Exception as e:
+            print("ERROR: Unable to handle response processing.")
+            print(e)
             sys.exit(-1)
 
         try:
@@ -190,9 +190,9 @@ if __name__ == '__main__':
 
             txcount+=1
             time.sleep(arg_framedelay)
-        except Exception, e:
-            print "ERROR: Unable to handle ACK response."
-            print e
+        except Exception as e:
+            print("ERROR: Unable to handle ACK response.")
+            print(e)
             sys.exit(-1)
 
         seqnum += 1

--- a/tools/zbassocflood
+++ b/tools/zbassocflood
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import sys
 import os
 import signal

--- a/tools/zbconvert
+++ b/tools/zbconvert
@@ -22,18 +22,18 @@ parser.add_argument('-c', '--count', action='store', type=int, default=-1)
 args = parser.parse_args()
 
 if args.noclobber and os.path.exists(args.outfile):
-    print >>sys.stderr, "ERROR: Output file \"%s\" already exists." % args.outfile
+    print("ERROR: Output file \"%s\" already exists." % args.outfile, file=sys.stderr)
     sys.exit(1)
 
 if not os.path.exists(args.infile):
-    print >>sys.stderr, "ERROR: Input file \"%s\" does not exist." % args.infile
+    print("ERROR: Input file \"%s\" does not exist." % args.infile, file=sys.stderr)
     sys.exit(1)
 
 # Check if the input file is libpcap; if not, assume SNA.
 outcap = None
 try:
     pr = PcapReader(args.infile)
-except Exception, e:
+except Exception as e:
     if e.args == ('Unsupported pcap header format or version',):
         # Input file was not pcap, open it as SNA
         incap = DainTreeReader(args.infile)
@@ -56,5 +56,5 @@ while args.count != packetcount:
 
 incap.close()
 outcap.close()
-print("Converted {0} packets.".format(packetcount))
+print(("Converted {0} packets.".format(packetcount)))
 

--- a/tools/zbconvert
+++ b/tools/zbconvert
@@ -7,6 +7,7 @@ Note: timestamps are not preserved in the conversion process. Sorry.
 (jwright@willhackforsushi.com)
 '''
 
+from __future__ import print_function
 import sys
 import os.path
 import argparse

--- a/tools/zbdsniff
+++ b/tools/zbdsniff
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-
+from __future__ import print_function
 from optparse import OptionParser
 
 from killerbee.scapy_extensions import *

--- a/tools/zbdsniff
+++ b/tools/zbdsniff
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+
 from optparse import OptionParser
 
 from killerbee.scapy_extensions import *

--- a/tools/zbdump
+++ b/tools/zbdump
@@ -7,6 +7,7 @@ Compatible with Wireshark 1.1.2 and later (jwright@willhackforsushi.com)
 The -p flag adds CACE PPI headers to the PCAP (ryan@rmspeers.com)
 '''
 
+from __future__ import print_function
 import sys
 import signal
 import argparse

--- a/tools/zbdump
+++ b/tools/zbdump
@@ -26,7 +26,7 @@ def interrupt(signum, frame):
         pd.close()
     if dt:
         dt.close()
-    print("\n{0} packets captured".format(packetcount))
+    print(("\n{0} packets captured".format(packetcount)))
     sys.exit(0)
 
 # PcapDumper, only used if -w is specified
@@ -60,11 +60,11 @@ if args.verbose:
     unbuffered = os.fdopen(sys.stdout.fileno(), 'w', 0)
 
 if args.channel == None:
-    print >>sys.stderr, "ERROR: Must specify a channel."
+    print("ERROR: Must specify a channel.", file=sys.stderr)
     sys.exit(1)
 
 if args.pcapfile is None and args.dsnafile is None:
-    print >>sys.stderr, "ERROR: Must specify a savefile with -w (libpcap) or -W (Daintree SNA)"
+    print("ERROR: Must specify a savefile with -w (libpcap) or -W (Daintree SNA)", file=sys.stderr)
     sys.exit(1)
 elif args.pcapfile is not None:
     pd = PcapDumper(DLT_IEEE802_15_4, args.pcapfile, ppi=args.ppi)
@@ -79,7 +79,7 @@ else:
 kb = KillerBee(device=args.devstring)
 signal.signal(signal.SIGINT, interrupt)
 if not kb.is_valid_channel(args.channel, args.subghz_page):
-    print >>sys.stderr, "ERROR: Must specify a valid IEEE 802.15.4 channel for the selected device."
+    print("ERROR: Must specify a valid IEEE 802.15.4 channel for the selected device.", file=sys.stderr)
     kb.close()
     sys.exit(1)
 kb.set_channel(args.channel, args.subghz_page)
@@ -87,7 +87,7 @@ kb.sniffer_on()
 
 #rf_freq_mhz = (args.channel - 10) * 5 + 2400
 rf_freq_mhz = kb.frequency(args.channel, args.subghz_page) / 1000.0
-print("zbdump: listening on \'{0}\', channel {1}, page {2} ({3} MHz), link-type DLT_IEEE802_15_4, capture size 127 bytes".format(kb.get_dev_info()[0], args.channel, args.subghz_page, rf_freq_mhz))
+print(("zbdump: listening on \'{0}\', channel {1}, page {2} ({3} MHz), link-type DLT_IEEE802_15_4, capture size 127 bytes".format(kb.get_dev_info()[0], args.channel, args.subghz_page, rf_freq_mhz)))
 
 while args.count != packetcount:
     packet = kb.pnext()
@@ -111,5 +111,5 @@ if pd:
 if dt:
     dt.close()
 
-print("{0} packets captured".format(packetcount))
+print(("{0} packets captured".format(packetcount)))
 

--- a/tools/zbfind
+++ b/tools/zbfind
@@ -41,7 +41,7 @@ from killerbee import *
 from types import *
 
 if gtk.pygtk_version < (2,3,93):
-    print "PyGtk 2.3.93 or later required"
+    print("PyGtk 2.3.93 or later required")
     raise SystemExit
 
 try:
@@ -718,7 +718,7 @@ class ZBFindUI:
 
             self.updatelist = [ ]
 
-        except Exception, e:
+        except Exception as e:
             traceback.print_exc()
             sys.stderr.write("Could not open the window.  Check $DISPLAY.\n")
             sys.exit(-1)
@@ -894,9 +894,9 @@ class ZBPoller(Thread):
         beaconinj = ''.join([beaconp1, "%c"%self.seq, beaconp2])
         try:
             self.kb.inject(beaconinj)
-        except Exception, e:
-            print "ERROR: Unable to inject packet"
-            print e
+        except Exception as e:
+            print("ERROR: Unable to inject packet")
+            print(e)
 
         if self.seq > 255:
             self.seq = 0
@@ -941,7 +941,7 @@ class ZBPoller(Thread):
                     # TODO: Add debug message mode in case users want these otherwise-useless debug msgs
                     #print "we may have crashed -- i toggled the interface"
                     thresh = 0
-            except Exception,e:
+            except Exception as e:
                 traceback.print_exc()
                 continue
 
@@ -958,9 +958,9 @@ class ZBPoller(Thread):
             rssi = (3*packetlist[2])-91
             try:
                 packet = d154.pktchop(packetlist[0])
-            except Exception,e:
+            except Exception as e:
                 traceback.print_exc()
-                print "bad packetchop!!"
+                print("bad packetchop!!")
                 continue
 
 
@@ -1103,7 +1103,7 @@ class ZBPoller(Thread):
         try:
             self.stopthread.set()
             sys.exit(0)
-        except Exception, e:
+        except Exception as e:
             traceback.print_exc()
             sys.exit(1)
 
@@ -1128,5 +1128,5 @@ if __name__ == "__main__":
         zbpoll.stop()
         zbpoll.join()
         
-    except Exception,e:
+    except Exception as e:
         traceback.print_exc()

--- a/tools/zbgoodfind
+++ b/tools/zbgoodfind
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function
 import sys
 import random
 import signal

--- a/tools/zbgoodfind
+++ b/tools/zbgoodfind
@@ -5,14 +5,14 @@ import signal
 from killerbee import *
 
 def usage():
-    print >>sys.stderr, """
+    print("""
 zbgoodfind - search a binary file to identify the encryption key for a given
 SNA or libpcap IEEE 802.15.4 encrypted packet - jwright@willhackforsushi.com
 
 Usage: zbgoodfind [-frRFd] [-f binary file] [-r pcapfile] [-R daintreefile] 
          [-F Don't skip 2-byte FCS at end of each frame]
          [-d genenerate binary file (test mode)]
-    """
+    """, file=sys.stderr)
 
 def testmode():
     '''
@@ -47,15 +47,15 @@ def keysearch(packet, searchdata):
     searchdatalen = len(searchdata)
     while (offset < (searchdatalen - 16)):
         if arg_verbose:
-	        print "Calling decrypt with key:",
-	        for i in xrange(0,16):
-	            print "%02x" % ord(searchdata[offset+i]),
+	        print("Calling decrypt with key:", end=' ')
+	        for i in range(0,16):
+	            print("%02x" % ord(searchdata[offset+i]), end=' ')
         guesses += 1
         if d.decrypt(packet, searchdata[offset:offset+16]) != '':
-            print "Key found after %d guesses: " % guesses,
-            for i in xrange(0,15):
+            print("Key found after %d guesses: " % guesses, end=' ')
+            for i in range(0,15):
                 sys.stdout.write("%02x:" % ord(searchdata[offset+i]))
-            print "%02x" % ord(searchdata[offset+15])
+            print("%02x" % ord(searchdata[offset+15]))
             return True
         else:
             offset+=1
@@ -92,12 +92,12 @@ while len(sys.argv) > 1:
         sys.exit(0)
  
 if arg_searchfile == None:
-    print >>sys.stderr, "ERROR: Must specify a search file with -f"
+    print("ERROR: Must specify a search file with -f", file=sys.stderr)
     usage()
     sys.exit(1)
 
 if arg_pcapfile == None and arg_dsnafile == None:
-    print >>sys.stderr, "ERROR: Must specify a file with frames to decrypt with -r (pcap) or -R (Daintree SNA)"
+    print("ERROR: Must specify a file with frames to decrypt with -r (pcap) or -R (Daintree SNA)", file=sys.stderr)
     usage()
     sys.exit(1)
 
@@ -116,7 +116,7 @@ elif (arg_dsnafile != None):
 signal.signal(signal.SIGINT, interrupt)
 
 
-print "zbgoodfind: searching the contents of %s for encryption keys with the first encrypted packet in %s." % (arg_searchfile, savefile)
+print("zbgoodfind: searching the contents of %s for encryption keys with the first encrypted packet in %s." % (arg_searchfile, savefile))
 
 packetfound=0
 packetcount=0
@@ -131,24 +131,24 @@ while 1:
         if (fcf & DOT154_FCF_SEC_EN) == 0:
             # Packet is not encrypted
             if arg_verbose:
-                print "Skipping unencrypted packet %d." % packetcount
+                print("Skipping unencrypted packet %d." % packetcount)
             continue
 
         packetfound=1
         if arg_skipfcs:
             packet = packet[:-2]
         if arg_verbose:
-            print "Starting key search with packet %d." % packetcount
+            print("Starting key search with packet %d." % packetcount)
         if keysearch(packet, searchdata) == True:
             break
         else:
-            print "Failed to locate the encryption key for frame %d." % packetcount
+            print("Failed to locate the encryption key for frame %d." % packetcount)
 
     except TypeError:       # raised when pnext returns Null (end of capture)
         break
 
 if packetfound == 0:
-    print "No encrypted packets found in the capture file %s." % savefile
+    print("No encrypted packets found in the capture file %s." % savefile)
 
 cap.close()
 

--- a/tools/zbjammer
+++ b/tools/zbjammer
@@ -5,6 +5,7 @@ zbjammer: enable Zigbee jamming (firmware option)
 rfidiot <adam@algroup.co.uk>
 """
 
+from __future__ import print_function
 import sys
 import time
 import signal

--- a/tools/zbjammer
+++ b/tools/zbjammer
@@ -17,7 +17,7 @@ def interrupt(signum, frame):
     try:
         kb.jammer_off()
     except:
-        print "\nAborted!"
+        print("\nAborted!")
     sys.exit(0)
 
 # Command-line arguments
@@ -33,24 +33,24 @@ if args.showdev:
     sys.exit(0)
 
 if args.channel == None:
-    print >>sys.stderr, "ERROR: Must specify a channel."
+    print("ERROR: Must specify a channel.", file=sys.stderr)
     sys.exit(1)
 
 kb = KillerBee(device=args.devstring)
 signal.signal(signal.SIGINT, interrupt)
 if not kb.is_valid_channel(args.channel, args.subghz_page):
-    print >>sys.stderr, "ERROR: Must specify a valid IEEE 802.15.4 channel/page for the selected device."
+    print("ERROR: Must specify a valid IEEE 802.15.4 channel/page for the selected device.", file=sys.stderr)
     kb.close()
     sys.exit(1)
 kb.set_channel(args.channel, page=args.subghz_page)
 
-print "zbjammer: jamming channel", args.channel
-print "*** WARNING: this may not actually work on your hardware! Check with spectrum analyser!"
-print "*** NOTICE: it is your responsibility to comply with local law. Please check radio spectrum laws in your area before"
-raw_input("    proceeding. Hit <ENTER> to continue or CTL-C to abort.")
+print("zbjammer: jamming channel", args.channel)
+print("*** WARNING: this may not actually work on your hardware! Check with spectrum analyser!")
+print("*** NOTICE: it is your responsibility to comply with local law. Please check radio spectrum laws in your area before")
+input("    proceeding. Hit <ENTER> to continue or CTL-C to abort.")
 if not kb.jammer_on():
     while 42:
         pass
 else:
-    print 'ERROR: could not set jammer mode!'
+    print('ERROR: could not set jammer mode!')
     sys.exit(1)

--- a/tools/zbkey
+++ b/tools/zbkey
@@ -13,27 +13,27 @@ from killerbee import *
 
 
 def usage():
-    print >>sys.stderr, """
+    print("""
 zbkey: Attempts to retrieve a key by sending the associate request followed by the data request after association response
        Example usage: ./zbkey -f 14 -s 0.1 -p aa1a -a 0fc8071c08c25100 -i [deviceid]
 
 Usage: ./zbkey -f [channel] -s 0.1 -p [PANID] -a [IEEE64bitaddress] -i [deviceid]
-    """
+    """, file=sys.stderr)
 
 
 def show_dev():
     '''Prints the list of connected devices to stdout.'''
     kb = KillerBee()
-    print "Dev\tProduct String\tSerial Number"
+    print("Dev\tProduct String\tSerial Number")
     for dev in kb.dev_list():
-        print "%s\t%s\t%s" % (dev[0], dev[1], dev[2])
+        print("%s\t%s\t%s" % (dev[0], dev[1], dev[2]))
 
 
 def interrupt(signum, frame):
     '''Handles shutdown when a signal is received.'''
     global kb
     kb.close()
-    print "Exiting..."
+    print("Exiting...")
     sys.exit(2)
 
 
@@ -47,13 +47,13 @@ def associate_response_handle(packet):
     @return A string representing the device's short address in hex notation,
             or none if the packet was not the length or type expected.
     '''
-    print "Length of packet received in associate_handle: {0}".format(len(packet))
-    print kbutils.hexdump(packet)
+    print("Length of packet received in associate_handle: {0}".format(len(packet)))
+    print(kbutils.hexdump(packet))
     if len(packet) > 24:
         # Offset to Command Type, check to be 0x02 for assoc response type
         if packet[21] == '\x02':
             if packet[24] != '\x00':
-                print("Association response status was not successful. Received {0}.".format(struct.unpack('B', packet[24])[0]))
+                print(("Association response status was not successful. Received {0}.".format(struct.unpack('B', packet[24])[0])))
                 return None
             # Offset to Response Assigned Short Addr (in assoc response type)
             return packet[22:24] #device's short address, as binary string
@@ -70,8 +70,8 @@ def transport_response_handle(packet):
     @return A string representing the key in hex notation,
             or none if the packet was not the length or type expected.
     '''
-    print "Length of packet received in transport_handle: {0}".format(len(packet))
-    print kbutils.hexdump(packet)
+    print("Length of packet received in transport_handle: {0}".format(len(packet)))
+    print(kbutils.hexdump(packet))
     if len(packet) > 19:
     	if packet[19] == '\x05':
         	key = packet[21:33]
@@ -142,15 +142,15 @@ while len(sys.argv) > 1:
         arg_IEEEdev = sys.argv.pop(1)
 
 if arg_channel == None:
-    print >>sys.stderr, "ERROR: Must specify a channel with -f"
+    print("ERROR: Must specify a channel with -f", file=sys.stderr)
     usage()
     sys.exit(1)
 if arg_panID == None:
-    print >>sys.stderr, "ERROR: Must specify a PAN ID"
+    print("ERROR: Must specify a PAN ID", file=sys.stderr)
     usage()
     sys.exit(1)
 if arg_IEE64addr == None or len(arg_IEE64addr) != 8:
-    print >>sys.stderr, "ERROR: Must specify a 64-bit address of the target"
+    print("ERROR: Must specify a 64-bit address of the target", file=sys.stderr)
     usage()
     sys.exit(1)
 
@@ -164,7 +164,7 @@ kb.set_channel(arg_channel)
 #   last byte is association request, 80 to request alloc addr only, can try other combos like c0
 assoc_packet = '\x23\xc8'+ASSOC_SEQNUM+arg_panID+ASSOC_DST+ASSOC_SRC_PANID+arg_IEE64addr+'\x01'+'\x80' # associate packet 
 
-print "Sending association packet..."
+print("Sending association packet...")
 #print kbutils.hexdump(assoc_packet)
 kb.inject(assoc_packet)
 
@@ -174,7 +174,7 @@ data_assoc_packet  = '\x63\xc8'+ASSOC_DATA_SEQNUM+arg_panID+ASSOC_DST+arg_IEE64a
 
 time.sleep(0.5)
 # send data after association packet
-print "Sending data request packet..."
+print("Sending data request packet...")
 #print kbutils.hexdump(data_assoc_packet)
 kb.inject(data_assoc_packet)
 
@@ -186,7 +186,7 @@ while (start+arg_delay > time.time()):
     recvpkt = kb.pnext()
     # Check for empty packet (timeout) and valid FCS
     if recvpkt != None and recvpkt['validcrc']:
-        print "Received frame"
+        print("Received frame")
         # If packet is an assocation response, get the assigned device
         # short address, else get None if packet isn't the right type
         value = associate_response_handle(recvpkt['bytes'])
@@ -194,11 +194,11 @@ while (start+arg_delay > time.time()):
             # Let's ack them to thank them for the join...
             kb.sniffer_off()
             kb.inject('\x02\x00'+getAckByte(recvpkt['bytes']))
-            print "Short address: {0}".format(value)
+            print("Short address: {0}".format(value))
             break
 
 if value == None:
-    print "Sorry, we didn't hear a device respond with an association response. Do you have an active target within range?"
+    print("Sorry, we didn't hear a device respond with an association response. Do you have an active target within range?")
     kb.sniffer_off()
     kb.close()
     sys.exit(1)
@@ -206,7 +206,7 @@ if value == None:
 # Now build a packet to issue the SECOND DATA REQUEST, for the key to be sent
 if value != None:
     data_key_packet = '\x63\x88'+DATA_KEY_SEQNUM+arg_panID+ASSOC_DST+value+'\x04' # data packet after association response 
-    print "Sending the data key packet..."
+    print("Sending the data key packet...")
     #print kbutils.hexdump(data_key_packet)
     kb.inject(data_key_packet)
 
@@ -220,12 +220,12 @@ if value != None:
         if recvpkt != None and recvpkt['validcrc']:
             receivedKey = transport_response_handle(recvpkt['bytes']) 
             if receivedKey != None:
-                print "Received key: {0}".format(receivedKey.encode("hex"))
+                print("Received key: {0}".format(receivedKey.encode("hex")))
                 kb.close()
                 sys.exit(0)
 
     if receivedKey == None:
-        print "Sorry, we didn't get a key. The effectiveness of this attack depends highly on the configuration of the target network."
+        print("Sorry, we didn't get a key. The effectiveness of this attack depends highly on the configuration of the target network.")
 
 kb.close()
 sys.exit(1)

--- a/tools/zbkey
+++ b/tools/zbkey
@@ -3,6 +3,8 @@
 # Edited by:      ryan@riverloopsecurity.com
 # Version:        BETA
 
+
+from __future__ import print_function
 import sys
 import signal
 import binascii

--- a/tools/zbopenear
+++ b/tools/zbopenear
@@ -36,11 +36,11 @@ if __name__ == '__main__':
         kbdev_info = kbutils.devlist(include=args.include, gps=args.ignore)
         channel = 11
         for i in range(0, len(kbdev_info)):
-            print 'Found device at %s: \'%s\'' % (kbdev_info[i][0], kbdev_info[i][1])
+            print('Found device at %s: \'%s\'' % (kbdev_info[i][0], kbdev_info[i][1]))
             if channel <= 26:
-                print '\tAssigning to channel %d.' % channel
+                print('\tAssigning to channel %d.' % channel)
                 startCapture(kbdev_info[i][0], channel)
                 channel += 1
     except KeyboardInterrupt:
-        print 'Shutting down'
+        print('Shutting down')
 

--- a/tools/zborphannotify
+++ b/tools/zborphannotify
@@ -14,7 +14,7 @@ from killerbee import *
 try:
     from scapy.all import *
 except ImportError:
-    print 'This tool requires Scapy to be installed (specifically scapy-com edition).'
+    print('This tool requires Scapy to be installed (specifically scapy-com edition).')
     from sys import exit
     exit(-1)
 
@@ -52,8 +52,8 @@ if __name__ == '__main__':
     parser.add_argument('--numloops', action='store', default=1, type=int)
     args = parser.parse_args()
 
-    print("Expecting {2:#016x} to be the coordinator on network (PAN ID) {0:#04x}, located on channel {1}.".format(args.panid, args.channel, args.coordinator))
-    print("The device to disassociate is {0:#016x}.".format(args.device))
+    print(("Expecting {2:#016x} to be the coordinator on network (PAN ID) {0:#04x}, located on channel {1}.".format(args.panid, args.channel, args.coordinator)))
+    print(("The device to disassociate is {0:#016x}.".format(args.device)))
     #print("The device to disassociate is {0:#016x} with short address {1:#04x}.".format(args.device, args.deviceshort))
     #TODO: seqnums for each direction
 
@@ -67,6 +67,6 @@ if __name__ == '__main__':
         seqnummac += 1
         if seqnummac > 255:
             seqnummac = 0
-        print sp.summary()
+        print(sp.summary())
         kb.inject(str(sp))
         sleep(0.005)

--- a/tools/zbpanidconflictflood
+++ b/tools/zbpanidconflictflood
@@ -3,6 +3,7 @@
 # Contributed by Bryan Halfpap <Bryanhalf@gmail.com>, Copyright 2015
 
 #TODO: Reduce the usage of globals
+from __future__ import print_function
 import signal
 import sys
 import argparse

--- a/tools/zbpanidconflictflood
+++ b/tools/zbpanidconflictflood
@@ -49,7 +49,7 @@ def get_spanids():
         try:
             recvpkt = listen.pnext()
         except:
-            print "Warning: Issue recieving packet."
+            print("Warning: Issue recieving packet.")
             pass  # TODO: Should this be continue instead?
         # Check for empty packet (timeout) and valid FCS
         if recvpkt != None and recvpkt['validcrc']:
@@ -57,11 +57,11 @@ def get_spanids():
             try:
                 canidate = struct.unpack('H', recvpkt['bytes'][3:5])[0]
             except:
-                print recvpkt['bytes'][3:5]
+                print(recvpkt['bytes'][3:5])
                 pass
             if canidate != None and canidate != spanid:
                 # OK we got a packet, lets go back up and send out a beacon$
-                print "Got beacon from {0}".format(hex(spanid))
+                print("Got beacon from {0}".format(hex(spanid)))
                 spanid = canidate
                 # Now start sending beacons on the gathered Source PAN ID by informing the other thread:
                 threading.spanid = spanid
@@ -71,7 +71,7 @@ def get_spanids():
         # TODO: Isolate the issue and file a bug.
         restart_threshold += 1
         if restart_threshold >= 15:
-            print "Crash is assumed - restarting sniffer interface.",
+            print("Crash is assumed - restarting sniffer interface.", end=' ')
             listen.sniffer_off()
             listen.sniffer_on()
             restart_threshold = 0
@@ -86,7 +86,7 @@ def inject():
         try:
             kb.inject(sp) #create_beacon returns a string
         except:
-            print "! - Injection Error, try slowing the rate of broadcast",
+            print("! - Injection Error, try slowing the rate of broadcast", end=' ')
             pass
     pass
 

--- a/tools/zbrealign
+++ b/tools/zbrealign
@@ -15,7 +15,7 @@ from killerbee import *
 try:
 	from scapy.all import *
 except ImportError:
-	print 'This tool requires Scapy to be installed (specifically scapy-com edition).'
+	print('This tool requires Scapy to be installed (specifically scapy-com edition).')
 	from sys import exit
 	exit(-1)
 
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     parser.add_argument('--numloops', action='store', default=1, type=int)
     args = parser.parse_args()
 
-    print("Expecting {2:#016x} to be the coordinator on network (PAN ID) {0:#04x}, located on channel {1}.".format(args.panid, args.channel, args.coordinator))
+    print(("Expecting {2:#016x} to be the coordinator on network (PAN ID) {0:#04x}, located on channel {1}.".format(args.panid, args.channel, args.coordinator)))
     #TODO: seqnums for each direction
 
     kb = KillerBee(device=args.devstring)

--- a/tools/zbreplay
+++ b/tools/zbreplay
@@ -19,7 +19,7 @@ def interrupt(signum, frame):
     kb.close()
     if cap:
         cap.close()
-    print("{0} packets transmitted".format(packetcount))
+    print(("{0} packets transmitted".format(packetcount)))
     sys.exit(0)
 
 def packet_ack(packet):
@@ -55,11 +55,11 @@ if args.showdev:
     sys.exit(0)
 
 if args.channel == None:
-    print >>sys.stderr, "ERROR: Must specify a channel."
+    print("ERROR: Must specify a channel.", file=sys.stderr)
     sys.exit(1)
 
 if args.pcapfile == None and args.dsnafile == None:
-    print >>sys.stderr, "ERROR: Must specify a file with frames to replay using -r (libpcap) or -R (Daintree SNA)"
+    print("ERROR: Must specify a file with frames to replay using -r (libpcap) or -R (Daintree SNA)", file=sys.stderr)
     sys.exit(1)
 elif args.pcapfile is not None:
     savefile = args.pcapfile
@@ -71,12 +71,12 @@ elif args.dsnafile is not None:
 kb = KillerBee(device=args.devstring)
 signal.signal(signal.SIGINT, interrupt)
 if not kb.is_valid_channel(args.channel, args.subghz_page):
-    print >>sys.stderr, "ERROR: Must specify a valid IEEE 802.15.4 channel/page for the selected device."
+    print("ERROR: Must specify a valid IEEE 802.15.4 channel/page for the selected device.", file=sys.stderr)
     kb.close()
     sys.exit(1)
 kb.set_channel(args.channel, page=args.subghz_page)
 
-print("zbreplay: retransmitting frames from \'{0}\' on interface \'{1}\' with a delay of {2} seconds.".format(savefile, kb.get_dev_info()[0], args.sleep))
+print(("zbreplay: retransmitting frames from \'{0}\' on interface \'{1}\' with a delay of {2} seconds.".format(savefile, kb.get_dev_info()[0], args.sleep)))
 
 while args.count != packetcount:
     try:
@@ -92,4 +92,4 @@ while args.count != packetcount:
 kb.close()
 cap.close()
 
-print("{0} packets transmitted".format(packetcount))
+print(("{0} packets transmitted".format(packetcount)))

--- a/tools/zbreplay
+++ b/tools/zbreplay
@@ -5,6 +5,7 @@ zbreplay: replay ZigBee/802.15.4 network traffic from libpcap or Daintree files
 jwright@willhackforsushi.com
 """
 
+from __future__ import print_function
 import sys
 import time
 import signal

--- a/tools/zbscapy
+++ b/tools/zbscapy
@@ -7,7 +7,7 @@ log_killerbee = logging.getLogger('scapy.killerbee')
 try:
 	from scapy.all import *
 except ImportError:
-	print 'This tool requires Scapy to be installed (specifically scapy-com edition).'
+	print('This tool requires Scapy to be installed (specifically scapy-com edition).')
 	from sys import exit
 	exit(-1)
 

--- a/tools/zbstumbler
+++ b/tools/zbstumbler
@@ -29,7 +29,7 @@ def display_details(routerdata):
     stackprofile = ord(stackprofilever) & 0x0f
     stackver = (ord(stackprofilever) & 0xf0) >>4
 
-    print "New Network: PANID 0x%02X%02X  Source 0x%02X%02X"%(ord(spanid[0]), ord(spanid[1]), ord(source[0]), ord(source[1]))
+    print("New Network: PANID 0x%02X%02X  Source 0x%02X%02X"%(ord(spanid[0]), ord(spanid[1]), ord(source[0]), ord(source[1])))
 
     try:
         extpanidstr=""
@@ -41,20 +41,20 @@ def display_details(routerdata):
         sys.stdout.write("\tExt PANID: Unknown")
 
     try:
-        print "\tStack Profile: %s"%stackprofile_map[stackprofile]
+        print("\tStack Profile: %s"%stackprofile_map[stackprofile])
         stackprofilestr = stackprofile_map[stackprofile]
     except KeyError:
-        print "\tStack Profile: Unknown (%d)"%stackprofile
+        print("\tStack Profile: Unknown (%d)"%stackprofile)
         stackprofilestr = "Unknown (%d)"%stackprofile
 
     try:
-        print("\tStack Version: {0}".format(stackver_map[stackver]))
+        print(("\tStack Version: {0}".format(stackver_map[stackver])))
         stackverstr = stackver_map[stackprofile]
     except KeyError:
-        print("\tStack Version: Unknown ({0})".format(stackver))
+        print(("\tStack Version: Unknown ({0})".format(stackver)))
         stackverstr = "Unknown (%d)"%stackver
 
-    print("\tChannel: {0}".format(channel))
+    print(("\tChannel: {0}".format(channel)))
 
     if args.csvfile is not None:
         csvfile.write("0x%02X%02X,0x%02X%02X,%s,%s,%s,%d\n"%(ord(spanid[0]), ord(spanid[1]), ord(source[0]), ord(source[1]), extpanidstr, stackprofilestr, stackverstr, channel))
@@ -101,7 +101,7 @@ def response_handler(stumbled, packet, channel):
         return value
 
     if args.verbose:
-        print("Received frame is not a beacon (FCF={0}).".format(pktdecode[0].encode('hex')))
+        print(("Received frame is not a beacon (FCF={0}).".format(pktdecode[0].encode('hex'))))
 
     return None
 
@@ -112,7 +112,7 @@ def interrupt(signum, frame):
     if args.csvfile is not None:
         csvfile.close()
     kb.close()
-    print("\n{0} packets transmitted, {1} responses.".format(txcount, rxcount))
+    print(("\n{0} packets transmitted, {1} responses.".format(txcount, rxcount)))
     sys.exit(0)
 
 if __name__ == '__main__':
@@ -135,7 +135,7 @@ if __name__ == '__main__':
         try:
             csvfile = open(args.csvfile, 'w')
         except Exception as e:
-            print("Issue opening CSV output file: {0}.".format(e))
+            print(("Issue opening CSV output file: {0}.".format(e)))
         csvfile.write("panid,source,extpanid,stackprofile,stackversion,channel\n")
 
     # Beacon frame
@@ -147,11 +147,11 @@ if __name__ == '__main__':
     try:
         kb = KillerBee(device=args.devstring)
     except KBInterfaceError as e:
-        print("Interface Error: {0}".format(e))
+        print(("Interface Error: {0}".format(e)))
         sys.exit(-1)
 
     signal.signal(signal.SIGINT, interrupt)
-    print("zbstumbler: Transmitting and receiving on interface \'{0}\'".format(kb.get_dev_info()[0]))
+    print(("zbstumbler: Transmitting and receiving on interface \'{0}\'".format(kb.get_dev_info()[0])))
 
     # Sequence number of beacon request frame
     seqnum = 0
@@ -171,11 +171,11 @@ if __name__ == '__main__':
 
         if not args.channel:
             if args.verbose:
-                print("Setting channel to {0}.".format(channel))
+                print(("Setting channel to {0}.".format(channel)))
             try:
                 kb.set_channel(channel)
-            except Exception, e:
-                print("ERROR: Failed to set channel to {0}. ({1})".format(channel, e))
+            except Exception as e:
+                print(("ERROR: Failed to set channel to {0}. ({1})".format(channel, e)))
                 sys.exit(-1)
 
         if args.verbose:
@@ -190,8 +190,8 @@ if __name__ == '__main__':
         try:
             txcount+=1
             kb.inject(beaconinj)
-        except Exception, e:
-            print("ERROR: Unable to inject packet: {0}".format(e))
+        except Exception as e:
+            print(("ERROR: Unable to inject packet: {0}".format(e)))
             sys.exit(-1)
 
         while (start+args.delay > time.time()):

--- a/tools/zbwardrive
+++ b/tools/zbwardrive
@@ -49,6 +49,6 @@ if __name__=='__main__':
         zbdb.close()
 
     except KeyboardInterrupt:
-        print 'Shutting down'
+        print('Shutting down')
         if zbdb != None: zbdb.close()
         if gpsp != None: gpsp.terminate()

--- a/tools/zbwireshark
+++ b/tools/zbwireshark
@@ -62,7 +62,7 @@ def main():
         try:
             kb.set_channel(args.channel, args.subghz_page)
         except ValueError as e:
-            print 'ERROR:', e
+            print('ERROR:', e)
             sys.exit(1)
 
         kb.sniffer_on()
@@ -76,7 +76,7 @@ def main():
             #rf_freq_mhz = (args.channel - 10) * 5 + 2400
             #print("zbwireshark: listening on \'{0}\'".format(kb.get_dev_info()[0]))
             rf_freq_mhz = kb.frequency(args.channel, args.subghz_page) / 1000.0
-            print("zbwireshark: listening on \'{0}\', channel {1}, page {2} ({3} MHz), link-type DLT_IEEE802_15_4, capture size 127 bytes".format(kb.get_dev_info()[0], args.channel, args.subghz_page, rf_freq_mhz))
+            print(("zbwireshark: listening on \'{0}\', channel {1}, page {2} ({3} MHz), link-type DLT_IEEE802_15_4, capture size 127 bytes".format(kb.get_dev_info()[0], args.channel, args.subghz_page, rf_freq_mhz)))
             try:
                 packetcount = 0
                 while args.count != packetcount:
@@ -85,7 +85,7 @@ def main():
 
                     rc = wireshark_proc.poll()
                     if rc is not None:
-                        print("Wireshark exited ({0})".format(rc))
+                        print(("Wireshark exited ({0})".format(rc)))
                         break
 
                     if packet != None:
@@ -102,7 +102,7 @@ def main():
                     raise
 
             kb.sniffer_off()
-            print("{0} packets captured".format(packetcount))
+            print(("{0} packets captured".format(packetcount)))
 
 if __name__ == '__main__':
     main()

--- a/zigbee_crypt/zigbee_crypt.c
+++ b/zigbee_crypt/zigbee_crypt.c
@@ -611,7 +611,11 @@ static PyObject *zigbee_sec_key_hash(PyObject *self, PyObject *args) {
     /* Hash the contents of hash_in to get the final result. */
     zbee_sec_hash(hash_in, 2*ZBEE_SEC_CONST_BLOCKSIZE, hash_out);
 
+#if PY_MAJOR_VERSION >= 3
 	return Py_BuildValue("y", hash_out);
+#else
+	return Py_BuildValue("s", hash_out);
+#endif
 } /* zbee_sec_key_hash */
 
 


### PR DESCRIPTION
This doesn't add full python3, it even doesn't allow zbid to work in python3. But it contains first steps towards the Python3 support. It it still compatible to Python2.7 .The following was made:
- Python3 Support for zigbee_crypt. This allow `pip3 install .` to work.
- Use relative paths for imports
- Remove unused imports where 
- Update the print statements to the print function. Imports also `print_function` from `__future__` where needed.
- Fix indentation

The performance differences between `range` and `xrange` in this code should be negligible, so I use `range` everywhere. The same is true for `dict.items()`.

If you want to keep a clean history, you can simply squash the commits. I decided to split it up in multiple parts, so the diffs of the separate parts are smaller.