### PR TITLE
Update dev_bumblebee driver to handle timeout for Py3

### DIFF
--- a/killerbee/dev_bumblebee.py
+++ b/killerbee/dev_bumblebee.py
@@ -360,7 +360,7 @@ class Bumblebee(object):
             self.set_channel(channel, page)
 
         for pnum in range(0, count):
-            print(self.send_packet(packet))
+            self.send_packet(packet)
             time.sleep(delay)
 
     # KillerBee expects the driver to implement this function

--- a/killerbee/dev_bumblebee.py
+++ b/killerbee/dev_bumblebee.py
@@ -144,8 +144,13 @@ class Bumblebee(object):
           nbytes = self.dev.read(Bumblebee.EP_IN, self.usb_rx_buffer, 100)
           if nbytes > 0:
             self.rx_buffer += self.usb_rx_buffer.tobytes()[:nbytes]
-        except usb.core.USBTimeoutError as usb_timeout:
-          pass
+        except usb.core.USBError as e:
+            if e.errno != 110: #Operation timed out
+                print("Error args: {}".format(e.args))
+                raise e
+                #TODO error handling enhancements for USB 1.0
+            else:
+                return None
 
     def send_message(self, command, data):
         """


### PR DESCRIPTION
Using the Bumblebee driver with a CC2531 stick, I kept getting a timeout error:

```
$ sudo zbdump -f 21 -i 3:3 -w out.pcap
Warning: You are using pyUSB 1.x, support is in beta.
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/killerbee-3.0.0b1-py3.9-linux-x86_64.egg/killerbee/dev_bumblebee.py", line 144, in process_rx
    nbytes = self.dev.read(Bumblebee.EP_IN, self.usb_rx_buffer, 100)
...
    except usb.core.USBTimeoutError as usb_timeout:
AttributeError: module 'usb.core' has no attribute 'USBTimeoutError'
```

Looks like this is just old code that needed updating to work with PyUSB 1.1 maybe? I took the exception handler code from another driver and replaced the old.