### PR TITLE
Bugfix: use b"" when joining in dev_rzusbstick.py

### DIFF
--- a/killerbee/dev_rzusbstick.py
+++ b/killerbee/dev_rzusbstick.py
@@ -605,7 +605,7 @@ class RZUSBSTICK:
                 # The last byte of frame data is the link quality indicator
                 ret['lqi'] = framedata[-1]
                 # Convert the framedata to a string for the return value
-                ret[0] = ''.join(framedata[:-1])
+                ret[0] = b''.join(framedata[:-1])
                 ret['bytes'] = ret[0]
                 return ret
             else:


### PR DESCRIPTION
I ran into this exception when trying out zbwireshark (from killerbee-3.0.0b2) with an Atmel RZUSBSTICK. The problem was that `bytes` can't be `join`'d from a `str`.

```
Traceback (most recent call last):
  File "/home/linuxbrew/.linuxbrew/bin/zbwireshark", line 4, in <module>
    __import__('pkg_resources').run_script('killerbee==3.0.0b2', 'zbwireshark')
  File "/home/linuxbrew/.linuxbrew/opt/python@3.9/lib/python3.9/site-packages/pkg_resources/__init__.py", line 651, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/home/linuxbrew/.linuxbrew/opt/python@3.9/lib/python3.9/site-packages/pkg_resources/__init__.py", line 1448, in run_script
    exec(code, namespace, namespace)
  File "/home/linuxbrew/.linuxbrew/lib/python3.9/site-packages/killerbee-3.0.0b2-py3.9-linux-x86_64.egg/EGG-INFO/scripts/zbwireshark", line 108, in <module>
    main()
  File "/home/linuxbrew/.linuxbrew/lib/python3.9/site-packages/killerbee-3.0.0b2-py3.9-linux-x86_64.egg/EGG-INFO/scripts/zbwireshark", line 84, in main
    packet = kb.pnext()
  File "/home/linuxbrew/.linuxbrew/opt/python@3.9/lib/python3.9/site-packages/killerbee-3.0.0b2-py3.9-linux-x86_64.egg/killerbee/__init__.py", line 442, in pnext
    return self.driver.pnext(timeout)
  File "/home/linuxbrew/.linuxbrew/opt/python@3.9/lib/python3.9/site-packages/killerbee-3.0.0b2-py3.9-linux-x86_64.egg/killerbee/dev_rzusbstick.py", line 608, in pnext
    ret[0] = ''.join(framedata[:-1])
TypeError: sequence item 0: expected str instance, bytes found
```

Fixes #239