### PR TITLE
Restore APS CMD payload parsing for NWK transport key disclosure

### DIFF
--- a/tools/zbdsniff
+++ b/tools/zbdsniff
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-
 from optparse import OptionParser
 
 from killerbee.scapy_extensions import *
@@ -29,7 +28,55 @@ KEY_TYPE = [
 ]
 
 
-def sniffNetworkKey(pkts, key, verbose):
+def bytestohex(b, sep=':'):
+    """
+    Convert bytes b to hex string using sep value as a delimiter.
+    This is what Python 3.8 `hex(bytes_per_sep)` does
+    """
+    assert(type(b) == bytes)
+    bstr = b.hex()
+    return sep.join([bstr[i:i+2] for i in range(0, len(bstr), 2)])
+
+
+def sniffApsTransportKey(pkts, verbose=False):
+    """
+    Search a Scapy PacketList of packets for APS_CMD_TRANSPORT_KEY type 5 (NWK key)
+    """
+    pcount = 0
+
+    if (verbose):
+        print("Searching packets for APS_CMD_TRANSPORT_KEY")
+
+    for p in pkts:
+        pcount += 1
+
+        if not (p.haslayer("ZigbeeAppCommandPayload")):
+            if (verbose):
+                print(f"Skipping packet {pcount}; no APS CMD payload")
+            continue
+
+        if (verbose):
+            print(f"Searching packet {pcount} for APS CMD identifier Transport Key (0x05)")
+
+        appcmd = p.getlayer("ZigbeeAppCommandPayload")
+
+        if (appcmd.cmd_identifier == 5 and appcmd.key_type == 1):
+
+            keystr = bytestohex(appcmd.key)
+            wiresharkkeystr = bytestohex(appcmd.key[::-1])
+            destaddrstr = bytestohex(appcmd.dest_addr.to_bytes(8, 'big'))
+            srcaddrstr = bytestohex(appcmd.src_addr.to_bytes(8, 'big'))
+
+            print(f"[+] Network Key: {keystr}")
+            print(f"      Wireshark: {wiresharkkeystr}")
+            print(f"      Dest Addr: {destaddrstr}")
+            print(f"       Src Addr: {srcaddrstr}")
+        else:
+            if (verbose):
+                print(f"Packet {pcount} lacks transport key identifier")
+
+
+def sniffAppDataKey(pkts, key, verbose):
     addrMap = dict()
     keyHash = sec_key_hash(key, '\0')
 
@@ -84,10 +131,6 @@ if __name__ == '__main__':
         print("A packet capture file or directory must be specified")
         sys.exit(1)
 
-    if (not options.transportKey):
-        print("A transport key value must be specified")
-        sys.exit(1)
-
     files = []
     if options.filename:
         files.append(options.filename)
@@ -108,7 +151,10 @@ if __name__ == '__main__':
             print("Exception: ", e)
             print("ERROR: Input file \"{}\" is not able to be loaded. Is it a PCAP file? Daintree support was removed in KillerBee 2.7.1".format(fname), file=sys.stderr)
             continue
-        sniffNetworkKey(pkts, options.transportKey, options.verbose)
+
+        if (options.transportKey):
+            sniffAppDataKey(pkts, options.transportKey, options.verbose)
+
+        sniffApsTransportKey(pkts, options.verbose)
 
     print("[+] Processed {} capture files.".format(filecount))
-


### PR DESCRIPTION
When I wrote `zbdsniff`, I wanted it to work like the classic Dug Song `dsniff` tool: read a pcap, and extract plaintext keys. When @SteveJM converted `zbdsniff` to Scapy in 61fbf5f3bf104132c665c1aeec34598e1c7d2ed3, we got a much simpler tool with a lot more extensibility since we can rely on Scapy decoding. However, in the process we lost the ability to extract transport keys sent in plaintext during device provisioning.

@SteveJM's changes added new capability to decrypt traffic and identify upper-layer keys, but require a key to be specified as a command line argument. This PR retains this functionality, and restores the ability to extract transport keys sent in unencrypted APS messages. If a key is not specified on the command line, then the APS decryption functionality @SteveJM added is skipped, but the extraction of transport keys will still work.

My implementation is a little inefficient, since it requires parsing all packets for each key recovery routine, but I figure this is not a huge problem for the typically small pcaps we work with in 802.15.4. Also, my `bytestohex()` function might better belong in a `utils` package; I added it just because list comprehension was getting annoying to convert bytes to he:xs:tr:in:gs.

Thanks!

-Josh