### PR TITLE
Add information about CC2531 and custom firmware that allows injecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The KillerBee framework is being expanded to support multiple devices.
 Currently there is support for the River Loop ApiMote, Atmel RZ RAVEN USB Stick,
 MoteIV Tmote Sky, TelosB mote, Sewino Sniffer, and various hardware running Silicon Labs Node Test firmware.
 
+The ApiMote, Atmel RZ RAVEN USB STICK and many of the other named devices are currently not available to buy on the internet. But with the CC2531 and [custom firmware](https://github.com/virtualabs/cc2531-killerbee-fw) a device for sniffing and injecting packets is still available.
 **See [firmware/README.md](firmware/README.md) for details on hardware support and firmware programming.**
 
 Support for Freaklab's Freakduino with added hardware & the Dartmouth arduino sketch

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -28,6 +28,9 @@ It can be purchased from electronics distributors, or directly from them
 
 _This is currently supported for beta, and supports sniffing only._
 
+### Virtualabs custom firmware (Allows injecting)
+
+When flashing the CC2531 with the [custom firmware ](https://github.com/virtualabs/cc2531-killerbee-fw) developed by @virtualabs it also supports injecting packages.
 
 ## Silicon Labs Node Test 2.4GHz & SubGHz
 


### PR DESCRIPTION
Hey all,
First of all thanks a lot for this awesome tool!

When starting using KillerBee a few weeks back I had the issue buying a device that is supported by KillerBee and allows injecting, as ApiMote, Raven USB stick and many others are not available on the internet anymore.
After some research, I found that the CC2531 with [custom firmware](https://github.com/virtualabs/cc2531-killerbee-fw) allows injecting packets. Also with a pretty reasonable price.

Long story short I noticed someone else having the same [issue](https://github.com/riverloopsec/killerbee/issues/265) as [me back then](https://github.com/riverloopsec/killerbee/issues/262). Therefore I think it makes sense to update the readme a bit to point the new users directly to an available device.